### PR TITLE
Route access request submissions to confirmation page

### DIFF
--- a/app/controllers/access_requests_controller.rb
+++ b/app/controllers/access_requests_controller.rb
@@ -1,6 +1,4 @@
 class AccessRequestsController < ApplicationController
-  before_action :set_access_request, only: [:show]
-
   # GET /access_requests/1
   def show
   end
@@ -24,11 +22,6 @@ class AccessRequestsController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_access_request
-      @access_request = AccessRequest.find(params[:id])
-    end
-
     # Only allow a trusted parameter "white list" through.
     def access_request_params
       params.require(:access_request).permit(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   root to: 'access_requests#new'
 
   resources :access_requests, only: [:new, :create, :show]
+  get 'access_request/confirmation', to: 'access_requests#show'
 
   namespace :admin do
     root to: 'access_requests#index'

--- a/spec/controllers/access_requests_controller_spec.rb
+++ b/spec/controllers/access_requests_controller_spec.rb
@@ -55,11 +55,6 @@ RSpec.describe AccessRequestsController, type: :controller do
   let(:valid_session) { {} }
 
   describe "GET #show" do
-    it "assigns the requested access_request as @access_request" do
-      access_request = AccessRequest.create! valid_attributes
-      get :show, params: {id: access_request.to_param}, session: valid_session
-      expect(assigns(:access_request)).to eq(access_request)
-    end
   end
 
   describe "GET #new" do
@@ -85,7 +80,7 @@ RSpec.describe AccessRequestsController, type: :controller do
 
       it "redirects to the created access_request" do
         post :create, params: {access_request: valid_attributes}, session: valid_session
-        expect(response).to redirect_to(AccessRequest.last)
+        expect(response).to redirect_to(access_request_confirmation_url)
       end
     end
 


### PR DESCRIPTION
Removes direct routing to show action for a particular access request from the end user (public).