### PR TITLE
Locks down endpoints under API controller

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -1,9 +1,15 @@
 class Api::ApiController < ApplicationController
-  # before_action :authenticate!
+  before_action :authenticate!
 
   protected
 
   def authenticate!
-    # raise 'Unauthenticated'
+    raise 'Missing auth' if ENV['API_AUTH'].blank?
+
+    auth = params[:auth] || request.headers['Authorization']
+
+    if auth != ENV['API_AUTH']
+      render json: { error: 'Unauthorised'  }, status: 403
+    end
   end
 end

--- a/spec/controllers/api/tokens_controller_spec.rb
+++ b/spec/controllers/api/tokens_controller_spec.rb
@@ -1,22 +1,36 @@
 require 'rails_helper'
 
 RSpec.describe Api::TokensController, type: :controller do
-  # This should return the minimal set of values that should be in the session
-  # in order to pass any filters (e.g. authentication) defined in
-  # TokensController. Be sure to keep this updated too.
-  let(:valid_session) { {} }
+  before do
+    ENV['API_AUTH'] = 'foobar123'
+  end
 
   describe '#revoked' do
-    let(:token_1) { create(:token) }
-    let(:token_2) { create(:token) }
-    let(:token_3) { create(:token) }
+    context 'when auth header provided' do
+      let(:token_1) { create(:token) }
+      let(:token_2) { create(:token) }
+      let(:token_3) { create(:token) }
 
-    it 'returns a list of the fingerprints of the revoked tokens' do
-      token_1.revoke!
-      token_3.revoke!
+      it 'returns a list of the fingerprints of the revoked tokens' do
+        token_1.revoke!
+        token_3.revoke!
 
-      get :revoked, params: {}, session: valid_session
-      expect(JSON.parse(response.body)).to eq([token_1.fingerprint, token_3.fingerprint])
+        request.headers['Authorization'] = 'foobar123'
+        get :revoked, params: {}
+        expect(JSON.parse(response.body)).to eq([token_1.fingerprint, token_3.fingerprint])
+      end
+    end
+
+    context 'when auth header not provided' do
+      before { get :revoked, params: {} }
+
+      it 'renders json error' do
+        expect(JSON.parse(response.body)).to eq({ 'error' => 'Unauthorised' })
+      end
+
+      it 'returns 403' do
+        expect(response.status).to eq(403)
+      end
     end
   end
 end


### PR DESCRIPTION
Locks down API endpoints with simple auth param/header. Password/secret set via environment variable.