### PR TITLE
Validate uploaded client public key is correct

### DIFF
--- a/app/controllers/access_requests_controller.rb
+++ b/app/controllers/access_requests_controller.rb
@@ -31,6 +31,7 @@ class AccessRequestsController < ApplicationController
         :reason,
         :api_env,
         :client_pub_key_file,
+        :client_pub_key
       )
     end
 end

--- a/app/models/access_request.rb
+++ b/app/models/access_request.rb
@@ -1,16 +1,18 @@
 class AccessRequest < ApplicationRecord
   attr_accessor :client_pub_key_file
 
-  validates :requested_by, :contact_email, :reason, :api_env, :client_pub_key_file, presence: :true
+  validates :requested_by, :contact_email, :reason, :api_env, :client_pub_key,
+    presence: :true
+
+  validates :client_pub_key, ec_public_key: true
   validates :api_env, inclusion: Token::API_ENVS
   validates_email_format_of :contact_email
 
-  before_save :set_client_pub_key
+  before_validation :set_client_pub_key
 
   private
 
   def set_client_pub_key
-    self.client_pub_key = client_pub_key_file.read
+    self.client_pub_key = self.client_pub_key_file.read if self.client_pub_key_file.present?
   end
-
 end

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -6,8 +6,8 @@ class Token < ApplicationRecord
   validates :issued_at, :requested_by, :service_name, :fingerprint, :api_env,
     :expires, :contact_email, :client_pub_key, presence: :true
 
+  validates :client_pub_key, ec_public_key: true
   validates :api_env, inclusion: Token::API_ENVS
-
   validates_email_format_of :contact_email
 
   scope :revoked, -> { where(revoked: true) }

--- a/app/validators/ec_public_key_validator.rb
+++ b/app/validators/ec_public_key_validator.rb
@@ -1,0 +1,15 @@
+class EcPublicKeyValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    regex = /\A-----BEGIN PUBLIC KEY-----.+-----END PUBLIC KEY-----\Z/m
+
+    begin
+      OpenSSL::PKey::EC.new(value)
+
+      if value !~ regex
+        record.errors[attribute] << (options[:message] || 'is not a public key')
+      end
+    rescue
+      record.errors[attribute] << (options[:message] || 'is not a valid EC certificate/key')
+    end
+  end
+end

--- a/app/validators/ec_public_key_validator.rb
+++ b/app/validators/ec_public_key_validator.rb
@@ -3,6 +3,8 @@ class EcPublicKeyValidator < ActiveModel::EachValidator
     begin
       key = OpenSSL::PKey::EC.new(value)
 
+      # Calling #public_key? returns true for both public and private key,
+      # #private_key seems to behave correctly.
       if key.private_key?
         record.errors[attribute] << (options[:message] || 'is not a public key')
       end

--- a/app/validators/ec_public_key_validator.rb
+++ b/app/validators/ec_public_key_validator.rb
@@ -1,11 +1,9 @@
 class EcPublicKeyValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    regex = /\A-----BEGIN PUBLIC KEY-----.+-----END PUBLIC KEY-----\Z/m
-
     begin
-      OpenSSL::PKey::EC.new(value)
+      key = OpenSSL::PKey::EC.new(value)
 
-      if value !~ regex
+      if key.private_key?
         record.errors[attribute] << (options[:message] || 'is not a public key')
       end
     rescue

--- a/spec/factories/access_requests.rb
+++ b/spec/factories/access_requests.rb
@@ -5,6 +5,6 @@ FactoryGirl.define do
     service_name 'some_app'
     api_env 'preprod'
     reason 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
-    client_pub_key_file { File.open("#{Rails.root}/spec/fixtures/test_client.pub") }
+    client_pub_key { File.open("#{Rails.root}/spec/fixtures/test_client.pub").read }
   end
 end

--- a/spec/models/access_request_spec.rb
+++ b/spec/models/access_request_spec.rb
@@ -1,11 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe AccessRequest, type: :model do
+  it_behaves_like 'an EC Public Key validatable'
+
   it { should validate_presence_of(:contact_email) }
   it { should validate_presence_of(:requested_by) }
   it { should validate_presence_of(:reason) }
-  it { should validate_presence_of(:client_pub_key_file) }
-
+  it { should validate_presence_of(:client_pub_key) }
   it { should validate_inclusion_of(:api_env).in_array(Token::API_ENVS) }
 
   describe 'sets the client pub key' do

--- a/spec/models/token_spec.rb
+++ b/spec/models/token_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Token, type: :model do
+  it_behaves_like 'an EC Public Key validatable'
+
   it { should validate_presence_of(:issued_at) }
   it { should validate_presence_of(:requested_by) }
   it { should validate_presence_of(:service_name) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,6 +11,8 @@ require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'shoulda/matchers'
 
+Dir["./spec/support/**/*.rb"].each {|f| require f}
+
 include ActionDispatch::TestProcess
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/support/ec_public_key_validatable.rb
+++ b/spec/support/ec_public_key_validatable.rb
@@ -1,0 +1,48 @@
+shared_examples 'an EC Public Key validatable' do |attribute_name: :client_pub_key|
+  let(:ec_public_key_validatable) { build(described_class.to_s.underscore.to_sym) }
+  let(:ec_public_key) { fixture_file_upload('test_client.pub', 'text/plain').read }
+  let(:ec_private_key) { fixture_file_upload('test_client.key', 'text/plain').read }
+
+  describe 'validation' do
+    context 'valid' do
+      it 'is valid when the the property is a valid EC public key' do
+        ec_public_key_validatable.instance_variable_set("@#{attribute_name}", ec_public_key)
+        ec_public_key_validatable.valid?
+
+        expect(ec_public_key_validatable).to be_valid
+      end
+    end
+
+    context 'invalid' do
+      context 'when valid EC key but not a public key' do
+        before do
+          ec_public_key_validatable.client_pub_key = ec_private_key
+          ec_public_key_validatable.valid?
+        end
+
+        it 'is a valid EC key but not a public key' do
+          expect(ec_public_key_validatable).to_not be_valid
+        end
+
+        it 'adds a validation error when not valid' do
+          expect(ec_public_key_validatable.errors[attribute_name]).to include('is not a public key')
+        end
+      end
+
+      context 'when not valid in any way' do
+        before do
+          ec_public_key_validatable.client_pub_key = 'foobar'
+          ec_public_key_validatable.valid?
+        end
+
+        it 'is not valid when the the property is not a valid EC public key' do
+          expect(ec_public_key_validatable).to_not be_valid
+        end
+
+        it 'adds a validation error when not valid' do
+          expect(ec_public_key_validatable.errors[attribute_name]).to include('is not a valid EC certificate/key')
+        end
+      end
+    end
+  end
+end

--- a/spec/support/ec_public_key_validatable.rb
+++ b/spec/support/ec_public_key_validatable.rb
@@ -4,8 +4,8 @@ shared_examples 'an EC Public Key validatable' do |attribute_name: :client_pub_k
   let(:ec_private_key) { fixture_file_upload('test_client.key', 'text/plain').read }
 
   describe 'validation' do
-    context 'valid' do
-      it 'is valid when the the property is a valid EC public key' do
+    context 'when the the property is a valid EC public key' do
+      it 'is valid' do
         ec_public_key_validatable.instance_variable_set("@#{attribute_name}", ec_public_key)
         ec_public_key_validatable.valid?
 
@@ -13,8 +13,8 @@ shared_examples 'an EC Public Key validatable' do |attribute_name: :client_pub_k
       end
     end
 
-    context 'invalid' do
-      context 'when valid EC key but not a public key' do
+    context 'when the the property is not a valid EC public key' do
+      context 'is private EC key' do
         before do
           ec_public_key_validatable.client_pub_key = ec_private_key
           ec_public_key_validatable.valid?
@@ -29,7 +29,7 @@ shared_examples 'an EC Public Key validatable' do |attribute_name: :client_pub_k
         end
       end
 
-      context 'when not valid in any way' do
+      context 'is not valid' do
         before do
           ec_public_key_validatable.client_pub_key = 'foobar'
           ec_public_key_validatable.valid?


### PR DESCRIPTION
Custom validator to check the uploaded client public key is correct. Check with openssl to see if it is a valid EC PEM certificate and also checks if it is a public key and not the private one.

RSpec shared example used in the two models which use the validation.