### PR TITLE
Trackback token provisioning - In progress

### DIFF
--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -1,0 +1,26 @@
+class TokensController < ApplicationController
+  before_action :set_token, only: [:new, :update]
+
+  # GET /tokens/new
+  def new
+  end
+
+  # PATCH/PUT /tokens/1
+  def update
+    begin
+      payload = @token.provision_and_activate!
+      filename = "nomis-api_#{@token.service_name.downcase.underscore}_#{@token.api_env}.token"
+      send_data(payload, type: 'text/plain', disposition: 'attachment', filename: filename)
+    rescue
+      redirect_to new_token_url(trackback_token: params[:trackback_token]),
+        alert: 'Unable to provision token. Please contact team.'
+    end
+  end
+
+  private
+
+  def set_token
+    @token = Token.find_by(trackback_token: params[:trackback_token])
+    raise ActionController::RoutingError.new('Not Found') unless @token
+  end
+end

--- a/app/models/access_request.rb
+++ b/app/models/access_request.rb
@@ -10,6 +10,21 @@ class AccessRequest < ApplicationRecord
 
   before_validation :set_client_pub_key
 
+  scope :processed, -> { where(processed: true) }
+  scope :unprocessed, -> { where.not(processed: true) }
+
+  def process!
+    update_attribute(:processed, true)
+  end
+
+  def processed?
+    !!processed
+  end
+
+  def unprocessed?
+    !processed?
+  end
+
   private
 
   def set_client_pub_key

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -1,19 +1,58 @@
 class Token < ApplicationRecord
   API_ENVS = %w( dev preprod prod ).freeze
+  STATES = %w( inactive active revoked ).freeze
 
   attr_accessor :client_pub_key_file
 
-  validates :issued_at, :requested_by, :service_name, :fingerprint, :api_env,
-    :expires, :contact_email, :client_pub_key, presence: :true
+  validates :requested_by, :service_name, :api_env, :expires, :contact_email,
+    :client_pub_key, presence: :true
 
   validates :client_pub_key, ec_public_key: true
   validates :api_env, inclusion: Token::API_ENVS
   validates_email_format_of :contact_email
 
-  scope :revoked, -> { where(revoked: true) }
-  scope :unrevoked, -> { where.not(revoked: true) }
+  before_validation :set_client_pub_key
+  after_create :set_trackback_token
+
+  scope :inactive, -> { where(state: 'inactive') }
+  scope :active, -> { where(state: 'active') }
+  scope :revoked, -> { where(state: 'revoked') }
+  scope :unrevoked, -> { where.not(state: 'revoked') }
+
+  def revoked?
+    state == 'revoked'
+  end
+
+  def inactive?
+    state == 'inactive'
+  end
+
+  def active?
+    state == 'active'
+  end
 
   def revoke!
-    update_attribute(:revoked, true)
+    update_attribute(:state, 'revoked')
+  end
+
+  def activate!
+    update_attribute(:trackback_token, nil)
+    update_attribute(:state, 'active')
+  end
+
+  def provision_and_activate!
+    output = ProvisionToken.call(token: self)
+    activate!
+    output
+  end
+
+  private
+
+  def set_client_pub_key
+    self.client_pub_key = self.client_pub_key_file.read if self.client_pub_key_file.present?
+  end
+
+  def set_trackback_token
+    update_attribute(:trackback_token, SecureRandom.uuid)
   end
 end

--- a/app/services/notify.rb
+++ b/app/services/notify.rb
@@ -5,6 +5,7 @@ module Notify
 
   CLIENT = Notifications::Client.new(ENV['GOVUK_NOTIFY_API_KEY'])
   ACCESS_REQUEST_NOTIFICATION_TEMPLATE = ENV['ACCESS_REQUEST_NOTIFICATION_TEMPLATE']
+  TOKEN_TRACKBACK_TEMPLATE = ENV['TOKEN_TRACKBACK_TEMPLATE']
   TEAM_EMAIL = ENV['TEAM_EMAIL']
 
   def service_team(access_request, link)
@@ -15,6 +16,20 @@ module Notify
         requestor: access_request.requested_by,
         env: access_request.api_env,
         access_request_link: link
+      }
+    )
+
+    email.id
+  end
+
+  def token_trackback(token, link)
+    email = CLIENT.send_email(
+      email_address: token.contact_email,
+      template_id: TOKEN_TRACKBACK_TEMPLATE,
+      personalisation: {
+        requestor: token.requested_by,
+        env: token.api_env,
+        trackback_link: link
       }
     )
 

--- a/app/views/admin/access_requests/index.html.haml
+++ b/app/views/admin/access_requests/index.html.haml
@@ -8,6 +8,7 @@
       %th Email
       %th Service
       %th Env
+      %th Processed
       %th
       %th
       %th
@@ -20,6 +21,11 @@
         %td= mail_to access_request.contact_email
         %td= access_request.service_name
         %td= access_request.api_env
+        %td= access_request.processed?
         %td= link_to 'Show', [:admin, access_request]
-        %td= link_to 'Approve', new_admin_token_path(access_request:access_request)
-        %td= link_to 'Reject', [:admin, access_request], method: :delete, data: { confirm: 'Are you sure?' }
+        %td
+          - if access_request.unprocessed?
+            = link_to 'Approve', new_admin_token_path(access_request:access_request)
+        %td
+          - if access_request.unprocessed?
+            = link_to 'Reject', [:admin, access_request], method: :delete, data: { confirm: 'Are you sure?' }

--- a/app/views/admin/tokens/_form.html.haml
+++ b/app/views/admin/tokens/_form.html.haml
@@ -2,6 +2,9 @@
   'There were problems submitting this form', ''
 
 = form_for [:admin, @token] do |f|
+  - if @access_request.present?
+    = hidden_field_tag :access_request_id, @access_request.id
+
   .field
     = f.text_field :requested_by
   .field

--- a/app/views/admin/tokens/index.html.haml
+++ b/app/views/admin/tokens/index.html.haml
@@ -9,22 +9,22 @@
       %th Service
       %th Env
       %th Expires
-      %th Revoked
+      %th Status
       %th
       %th
   %tbody
     - @tokens.each do |token|
       %tr
-        %td= l token.issued_at, format: :long
+        %td= l token.issued_at, format: :long rescue '-'
         %td= token.requested_by
         %td= mail_to token.contact_email
         %td= token.service_name
         %td= token.api_env
         %td= l token.expires rescue ''
-        %td= token.revoked? ? 'Yes' : 'No'
+        %td= token.state.humanize
         %td= link_to 'Show', [:admin, token]
         %td
-          - unless token.revoked?
+          - if token.active?
             = button_to 'Revoke', revoke_admin_token_path(token), method: :put, data: { confirm: 'Are you sure?' }, class: 'button'
 
 %br

--- a/app/views/admin/tokens/show.html.haml
+++ b/app/views/admin/tokens/show.html.haml
@@ -2,7 +2,7 @@
 
 %p
   %b Issued at:
-  = @token.issued_at
+  = @token.issued_at || ''
 %p
   %b Requested by:
   = @token.requested_by
@@ -22,7 +22,8 @@
   %b Expires:
   = l @token.expires rescue ''
 %p
-  %b Revoked:
-  = @token.revoked
-  
-= button_to 'Revoke', revoke_admin_token_path(@token), method: :put, data: { confirm: 'Are you sure?' }, class: 'button'
+  %b Status:
+  = @token.state.humanize
+
+- if @token.active?
+  = button_to 'Revoke', revoke_admin_token_path(@token), method: :put, data: { confirm: 'Are you sure?' }, class: 'button'

--- a/app/views/tokens/new.html.haml
+++ b/app/views/tokens/new.html.haml
@@ -1,0 +1,8 @@
+%p#notice= notice
+
+%p
+  Your access token is available for download below. Please note that this is a one time only download link and will expire once downloaded or in X days. If you have any issues please contact X.
+
+= form_for @token do |f|
+  = hidden_field_tag :trackback_token, @token.trackback_token
+  = f.submit 'Download', class: 'button'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
   resources :access_requests, only: [:new, :create, :show]
   get 'access_request/confirmation', to: 'access_requests#show'
 
+  resources :tokens, only: [:new, :update]
+
   namespace :admin do
     root to: 'access_requests#index'
 

--- a/db/migrate/20170428091543_create_tokens.rb
+++ b/db/migrate/20170428091543_create_tokens.rb
@@ -8,8 +8,9 @@ class CreateTokens < ActiveRecord::Migration[5.0]
       t.string :api_env
       t.datetime :expires
       t.string :contact_email
-      t.boolean :revoked, default: false
+      t.string :state, default: 'inactive'
       t.text :client_pub_key
+      t.text :trackback_token, index: true
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,10 +35,12 @@ ActiveRecord::Schema.define(version: 20170428092008) do
     t.string   "api_env"
     t.datetime "expires"
     t.string   "contact_email"
-    t.boolean  "revoked",        default: false
+    t.string   "state",           default: "inactive"
     t.text     "client_pub_key"
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
+    t.datetime "created_at",                           null: false
+    t.datetime "updated_at",                           null: false
+    t.text     "trackback_token"
+    t.index ["trackback_token"], name: "index_tokens_on_trackback_token", using: :btree
   end
 
 end

--- a/spec/controllers/access_requests_controller_spec.rb
+++ b/spec/controllers/access_requests_controller_spec.rb
@@ -60,6 +60,11 @@ RSpec.describe AccessRequestsController, type: :controller do
   end
 
   describe "POST #create" do
+    before do
+      response = double(id: 'f23caa')
+      allow(Notify::CLIENT).to receive(:send_email).and_return(response)
+    end
+
     context "with valid params" do
       it "creates a new AccessRequest" do
         expect {

--- a/spec/controllers/admin/tokens_controller_spec.rb
+++ b/spec/controllers/admin/tokens_controller_spec.rb
@@ -82,6 +82,11 @@ RSpec.describe Admin::TokensController, type: :controller do
   end
 
   describe "POST #create" do
+    before do
+      response = double(id: 'f23caa')
+      allow(Notify::CLIENT).to receive(:send_email).and_return(response)
+    end
+
     context "with valid params" do
       it "creates a new Token" do
         expect {
@@ -97,7 +102,7 @@ RSpec.describe Admin::TokensController, type: :controller do
 
       it "redirects to the created token" do
         post :create, params: {token: valid_attributes}, session: valid_session
-        expect(response).to redirect_to([:admin, Token.last])
+        expect(response).to redirect_to(admin_tokens_url)
       end
     end
 

--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe TokensController, type: :controller do
+  let(:token) { create(:token) }
+
+  describe "GET #new" do
+    context 'with a valid trackback token' do
+      it "returns http success" do
+        get :new, params: { trackback_token: token.trackback_token }
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context 'without a valid trackback token' do
+      it "raises 404" do
+        expect{ get :new, params: { trackback_token: 'xxxx' } }.to raise_exception(ActionController::RoutingError)
+      end
+    end
+
+    context 'with no trackback token' do
+      it "raises 404" do
+        expect{ get :new }.to raise_exception(ActionController::RoutingError)
+      end
+    end
+  end
+
+  describe "PATCH/PUT #update" do
+    context 'non valid trackback token' do
+      it 'raises 404' do
+        expect{ patch :update, params: { id: token, trackback_token: '123xxx' } }.to raise_exception(ActionController::RoutingError)
+      end
+    end
+
+    context 'valid trackback token' do
+      before do
+        patch :update, params: { id: token, trackback_token: token.trackback_token }
+        token.reload
+      end
+
+      it 'sets the token active' do
+        expect(token).to be_active
+      end
+
+      it 'sets the trackback_token to nil' do
+        expect(token.trackback_token).to be_nil
+      end
+
+      it 'returns the provisioned token' do
+        expect(response.body).to_not be_nil
+      end
+    end
+  end
+end

--- a/spec/factories/access_requests.rb
+++ b/spec/factories/access_requests.rb
@@ -6,5 +6,14 @@ FactoryGirl.define do
     api_env 'preprod'
     reason 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
     client_pub_key { File.open("#{Rails.root}/spec/fixtures/test_client.pub").read }
+    processed false
+
+    trait :unprocessed do
+      processed false
+    end
+
+    trait :processed do
+      processed true
+    end
   end
 end

--- a/spec/factories/tokens.rb
+++ b/spec/factories/tokens.rb
@@ -7,7 +7,19 @@ FactoryGirl.define do
     api_env 'preprod'
     expires { 1.year.from_now }
     contact_email { Faker::Internet.email }
-    revoked false
     client_pub_key { File.open("#{Rails.root}/spec/fixtures/test_client.pub").read }
+    state 'inactive'
+
+    trait :inactive do
+      state 'inactive'
+    end
+
+    trait :active do
+      state 'active'
+    end
+
+    trait :revoked do
+      state 'revoked'
+    end
   end
 end

--- a/spec/models/access_request_spec.rb
+++ b/spec/models/access_request_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe AccessRequest, type: :model do
   it_behaves_like 'an EC Public Key validatable'
 
+  subject { create(:access_request) }
+
   it { should validate_presence_of(:contact_email) }
   it { should validate_presence_of(:requested_by) }
   it { should validate_presence_of(:reason) }
@@ -20,5 +22,25 @@ RSpec.describe AccessRequest, type: :model do
       expect(subject.client_pub_key).to eq(File.read(client_pub_key_file))
     end
 
+  end
+
+  describe '#process!' do
+    it 'sets the access request to processed' do
+      subject.process!
+      expect(subject).to be_processed
+    end
+  end
+
+  describe '#unprocessed?' do
+    it 'check if the access request is unprocessed' do
+      expect(subject).to be_unprocessed
+    end
+  end
+
+  describe '#proceesed?' do
+    it 'checks if the access request is processed' do
+      subject.process!
+      expect(subject).to be_processed
+    end
   end
 end

--- a/spec/models/token_spec.rb
+++ b/spec/models/token_spec.rb
@@ -3,10 +3,8 @@ require 'rails_helper'
 RSpec.describe Token, type: :model do
   it_behaves_like 'an EC Public Key validatable'
 
-  it { should validate_presence_of(:issued_at) }
   it { should validate_presence_of(:requested_by) }
   it { should validate_presence_of(:service_name) }
-  it { should validate_presence_of(:fingerprint) }
   it { should validate_presence_of(:api_env) }
   it { should validate_presence_of(:expires) }
   it { should validate_presence_of(:contact_email) }
@@ -15,9 +13,9 @@ RSpec.describe Token, type: :model do
   it { should validate_inclusion_of(:api_env).in_array(Token::API_ENVS) }
 
   describe 'scopes' do
-    let(:unrevoked_token_1) { create(:token) }
-    let(:unrevoked_token_2) { create(:token) }
-    let(:revoked_token) { create(:token, revoked: true) }
+    let(:inactive_token) { create(:token) }
+    let(:active_token) { create(:token, :active) }
+    let(:revoked_token) { create(:token, :revoked) }
 
     describe '.revoked' do
       it 'returns only the revoked tokens' do
@@ -27,18 +25,75 @@ RSpec.describe Token, type: :model do
 
     describe '.unrevoked' do
       it 'returns only the unrevoked tokens' do
-        expect(described_class.unrevoked).to match_array([unrevoked_token_1, unrevoked_token_2])
+        expect(described_class.unrevoked).to match_array([active_token, inactive_token])
+      end
+    end
+
+    describe '.active' do
+      it 'returns only the active tokens' do
+        expect(described_class.active).to match_array([active_token])
+      end
+    end
+
+    describe '.inactive' do
+      it 'returns only the unrevoked tokens' do
+        expect(described_class.inactive).to match_array([inactive_token])
       end
     end
   end
 
   describe '#revoke!' do
-    let(:unrevoked_token) { create(:token, revoked: false) }
+    let(:active_token) { create(:token, :active) }
 
     it 'set revoked to true' do
-      unrevoked_token.revoke!
+      active_token.revoke!
 
-      expect(unrevoked_token).to be_revoked
+      expect(active_token).to be_revoked
+    end
+  end
+
+  describe '#activate!' do
+    let(:inactive_token) { create(:token, trackback_token: 'xxxx') }
+
+    before do
+      inactive_token.activate!
+    end
+
+    it 'sets the trackback_token to nil' do
+      expect(inactive_token.trackback_token).to be_nil
+    end
+
+    it 'marks the token as active' do
+      expect(inactive_token).to be_active
+    end
+  end
+
+  describe '#provision_and_activate!' do
+    let(:inactive_token) { create(:token, trackback_token: 'xxxx') }
+
+    it 'provisions the token' do
+      expect(inactive_token.provision_and_activate!).to_not be_nil
+    end
+
+    it 'sets issued_at' do
+      inactive_token.provision_and_activate!
+
+      expect(inactive_token.issued_at).to_not be_nil
+    end
+
+    it 'sets the fingerprint' do
+      inactive_token.provision_and_activate!
+
+      expect(inactive_token.fingerprint).to_not be_nil
+    end
+  end
+
+  describe 'trackback token' do
+    subject { build(:token, trackback_token: nil) }
+
+    it 'sets the trackback token after save' do
+      subject.save
+      expect(subject.trackback_token).to_not be_nil
     end
   end
 end

--- a/spec/routing/tokens_routing_spec.rb
+++ b/spec/routing/tokens_routing_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe TokensController, type: :routing do
+  describe "routing" do
+    it "routes to #new with a valid trackback token" do
+      create(:token, trackback_token: '123xxx')
+      expect(:get => "/tokens/new", params: { id: '123xxx' }).to route_to("tokens#new")
+    end
+
+    it "routes to #update via PUT" do
+      expect(:put => "/tokens/1").to route_to("tokens#update", :id => "1")
+    end
+
+    it "routes to #revoke via PATCH" do
+      expect(:patch => "/tokens/1").to route_to("tokens#update", :id => "1")
+    end
+  end
+end

--- a/spec/services/notify_spec.rb
+++ b/spec/services/notify_spec.rb
@@ -1,16 +1,29 @@
 require 'rails_helper'
 
 RSpec.describe Notify do
-  before do
-    allow(Notify).to receive(:service_team).with(access_request, access_request_link).and_return('06f063d1-776d-48ed-9253-6a32c443fcce')
-  end
-
   describe '#service_team' do
     let(:access_request) { create(:access_request) }
     let(:access_request_link) { "http://localhost:3000/access_requests/#{access_request.id}" }
 
+    before do
+      allow(Notify).to receive(:service_team).with(access_request, access_request_link).and_return('06f063d1-776d-48ed-9253-6a32c443fcce')
+    end
+
     it 'sends a request to GOV UK Notify and returns the notification id' do
       expect(Notify.service_team(access_request, access_request_link)).to eq('06f063d1-776d-48ed-9253-6a32c443fcce')
+    end
+  end
+
+  describe '#token_trackback' do
+    let(:token) { create(:token) }
+    let(:trackback_token) { "http://localhost:3000/tokens/new?trackback_token=#{token.trackback_token}" }
+
+    before do
+      allow(Notify).to receive(:token_trackback).with(token, trackback_token).and_return('96f063d1-996d-43ed-9253-6a32c423faaf')
+    end
+
+    it 'sends a request to GOV UK Notify and returns the notification id' do
+      expect(Notify.token_trackback(token, trackback_token)).to eq('96f063d1-996d-43ed-9253-6a32c423faaf')
     end
   end
 end


### PR DESCRIPTION
Token trackback link with controller action to provision and allow (one-time) download of produced token.

## Flows for provisioning tokens

### External user flow:

* User fills in and submits access request form
* GOV.UK Notify sends email with details and AccessRequest link to admin/team
* Admin approves or rejects (not yet implemented) AccessRequest - modifying as needed
* The Token record is created but marked inactive
* The AccessRequest is marked as "processed"
* GOV.UK Notify sends user email with a trackback link
* User follows link and is presented with a page to download the token from
* Token is provisioned, marked "active", setting its issued_at and fingerprint properties
* Provisioned token is sent to browser as an attachment, downloaded by user
* The trackback link is set to nil to prevent it from being followed again

### Admin/internal user flow:

* Admin fills in and submits Token form, including recipient's email address
* The Token record is created but marked inactive
* GOV.UK Notify sends the recipient an email with a trackback link
* User follows link and is presented with a page to download the token from
* Token is provisioned, marked "active", setting its issued_at and fingerprint properties
* Provisioned token is sent to browser as an attachment, downloaded by recipient
* The trackback link is set to nil to prevent it from being followed again
