### PR TITLE
Abstract API environments into model

### DIFF
--- a/app/models/access_request.rb
+++ b/app/models/access_request.rb
@@ -5,7 +5,7 @@ class AccessRequest < ApplicationRecord
     presence: :true
 
   validates :client_pub_key, ec_public_key: true
-  validates :api_env, inclusion: Token::API_ENVS
+  validates :api_env, inclusion: ApiEnv.all
   validates_email_format_of :contact_email
 
   before_validation :set_client_pub_key

--- a/app/models/api_env.rb
+++ b/app/models/api_env.rb
@@ -1,0 +1,7 @@
+class ApiEnv
+  ENVS = %w( dev preprod prod).freeze
+
+  def self.all
+    ENVS
+  end
+end

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -1,13 +1,11 @@
 class Token < ApplicationRecord
-  API_ENVS = %w( dev preprod prod ).freeze
-
   attr_accessor :client_pub_key_file
 
   validates :issued_at, :requested_by, :service_name, :fingerprint, :api_env,
     :expires, :contact_email, :client_pub_key, presence: :true
 
   validates :client_pub_key, ec_public_key: true
-  validates :api_env, inclusion: Token::API_ENVS
+  validates :api_env, inclusion: ApiEnv.all
   validates_email_format_of :contact_email
 
   scope :revoked, -> { where(revoked: true) }

--- a/app/services/retrieve_key.rb
+++ b/app/services/retrieve_key.rb
@@ -2,7 +2,7 @@ module RetrieveKey
   module_function
 
   def call(env)
-    raise ArgumentError, "Argument is not a valid env: #{Token::API_ENVS.join(', ')}" unless Token::API_ENVS.include? env
+    raise ArgumentError, "Argument is not a valid env: #{ApiEnv.all.join(', ')}" unless ApiEnv.all.include? env
 
     # Stubbed for testing/prototyping
     File.open("#{Rails.root}/spec/fixtures/test_provisioner.key").read

--- a/app/views/access_requests/_form.html.haml
+++ b/app/views/access_requests/_form.html.haml
@@ -11,7 +11,7 @@
   .field
     = f.text_area :reason
   .field
-    = f.collection_select :api_env, Token::API_ENVS, :to_s, :to_s, prompt: true
+    = f.collection_select :api_env, ApiEnv.all, :to_s, :to_s, prompt: true
   .field
     .form-group
       = f.label :client_pub_key_file, class: 'form-label' do

--- a/app/views/admin/tokens/_form.html.haml
+++ b/app/views/admin/tokens/_form.html.haml
@@ -9,7 +9,7 @@
   .field
     = f.text_field :contact_email
   .field
-    = f.collection_select :api_env, Token::API_ENVS, :to_s, :to_s, prompt: true
+    = f.collection_select :api_env, ApiEnv.all, :to_s, :to_s, prompt: true
   .field
     .form-group
       = f.label :expires, class: 'form-label' do

--- a/spec/models/access_request_spec.rb
+++ b/spec/models/access_request_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AccessRequest, type: :model do
   it { should validate_presence_of(:requested_by) }
   it { should validate_presence_of(:reason) }
   it { should validate_presence_of(:client_pub_key) }
-  it { should validate_inclusion_of(:api_env).in_array(Token::API_ENVS) }
+  it { should validate_inclusion_of(:api_env).in_array(ApiEnv.all) }
 
   describe 'sets the client pub key' do
     let(:client_pub_key_file) { fixture_file_upload('test_client.pub', 'text/plain') }

--- a/spec/models/api_env_spec.rb
+++ b/spec/models/api_env_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe ApiEnv, type: :model do
+  describe '.all' do
+    it 'returns the expected API environments' do
+      expect(described_class.all).to eq(['dev', 'preprod', 'prod'])
+    end
+  end
+end

--- a/spec/models/token_spec.rb
+++ b/spec/models/token_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Token, type: :model do
   it { should validate_presence_of(:contact_email) }
   it { should validate_presence_of(:client_pub_key) }
 
-  it { should validate_inclusion_of(:api_env).in_array(Token::API_ENVS) }
+  it { should validate_inclusion_of(:api_env).in_array(ApiEnv.all) }
 
   describe 'scopes' do
     let(:unrevoked_token_1) { create(:token) }


### PR DESCRIPTION
Moves the constant Token::API_ENVS into a plain Ruby class "ApiEnv" acting as a model. This was done to uncouple the constant from the Token model, as the values are used in many places in the app.