### PR TITLE
Provisioning keys basic management

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,13 @@ Users must have the 'admin' role to gain access to any admin controller methods.
 
     rake db:create db:migrate
     rails s
+
+### Disable authentication
+
+It is possible to disable authentication for testing:
+
+```
+$ AUTH_ENABLED=false rails s
+...
+[WARN] MOJSSO_ID/MOJSSO_SECRET/MOJSSO_URL not configured
+```

--- a/app/controllers/admin/admin_controller.rb
+++ b/app/controllers/admin/admin_controller.rb
@@ -1,7 +1,7 @@
 require 'custom_exceptions'
 
 class Admin::AdminController < ApplicationController
-  before_action :authenticate!, :ensure_admin!
+  before_action :authenticate!, :ensure_admin! if Rails.configuration.auth_enabled
 
   rescue_from Auth::NotAuthorized, with: :not_authorized
   rescue_from Auth::NotLoggedIn, with: :login_required

--- a/app/controllers/admin/provisioning_keys_controller.rb
+++ b/app/controllers/admin/provisioning_keys_controller.rb
@@ -1,0 +1,38 @@
+class Admin::ProvisioningKeysController < Admin::AdminController
+  before_action :set_provisioning_key, only: [:show, :destroy]
+
+  def index
+    @provisioning_keys = ProvisioningKey.all
+  end
+
+  def show
+  end
+
+  def new
+    @provisioning_key = ProvisioningKey.new
+  end
+
+  def create
+    @provisioning_key = ProvisioningKey.new(provisioning_key_params)
+    if @provisioning_key.save
+      redirect_to [:admin, @provisioning_key],
+        notice: "Provision key successfully created for environment #{@provisioning_key.api_env}"
+    else
+      render :new
+    end
+  end
+
+  def destroy
+    @provisioning_key.destroy
+    redirect_to admin_provisioning_keys_url, notice: 'Provisioning key was successfully destroyed.'
+  end
+
+  private
+    def provisioning_key_params
+      params.require(:provisioning_key).permit(:api_env, :content)
+    end
+
+    def set_provisioning_key
+      @provisioning_key = ProvisioningKey.find(params[:id])
+    end
+end

--- a/app/models/provisioning_key.rb
+++ b/app/models/provisioning_key.rb
@@ -2,4 +2,6 @@ class ProvisioningKey < ApplicationRecord
   validates :api_env, :content, presence: true
   validates :api_env, inclusion: ApiEnv.all
   validates :api_env, :content, uniqueness: true
+
+  validates :content, ec_private_key: true
 end

--- a/app/validators/ec_private_key_validator.rb
+++ b/app/validators/ec_private_key_validator.rb
@@ -1,0 +1,15 @@
+class EcPrivateKeyValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    begin
+      key = OpenSSL::PKey::EC.new(value)
+
+      # Calling #public_key? returns true for both public and private key,
+      # #private_key seems to behave correctly.
+      unless key.private_key?
+        record.errors[attribute] << (options[:message] || 'is not a EC private key')
+      end
+    rescue
+      record.errors[attribute] << (options[:message] || 'is not a valid EC private key')
+    end
+  end
+end

--- a/app/views/admin/provisioning_keys/_form.html.haml
+++ b/app/views/admin/provisioning_keys/_form.html.haml
@@ -1,0 +1,13 @@
+= GovukElementsErrorsHelper.error_summary @provisioning_key,
+  'There were problems submitting this form', ''
+
+= form_for [:admin, @provisioning_key] do |f|
+
+  .field
+    = f.collection_select :api_env, ApiEnv.all, :to_s, :to_s, prompt: true
+
+  .field
+    = f.text_area :content
+
+  .actions
+    = f.submit 'Submit', class: 'button'

--- a/app/views/admin/provisioning_keys/index.html.haml
+++ b/app/views/admin/provisioning_keys/index.html.haml
@@ -1,0 +1,21 @@
+%h1 Provisioning keys (#{@provisioning_keys.count})
+
+%table
+  %thead
+    %tr
+      %th Environment
+      %th Created at
+      %th Actions
+      %th
+
+  %tbody
+    - @provisioning_keys.each do |provisioning_key|
+      %tr
+        %td= provisioning_key.api_env
+        %td= l provisioning_key.created_at, format: :long
+        %td= link_to 'Show', admin_provisioning_key_url(provisioning_key)
+        %td= link_to 'Delete', [:admin, provisioning_key], method: :delete, data: { confirm: 'Are you sure?' }
+
+%br
+
+= link_to 'Create new key', new_admin_provisioning_key_url, class: 'button'

--- a/app/views/admin/provisioning_keys/new.html.haml
+++ b/app/views/admin/provisioning_keys/new.html.haml
@@ -1,0 +1,3 @@
+%h1 New provisioning key
+
+= render 'form'

--- a/app/views/admin/provisioning_keys/show.html.haml
+++ b/app/views/admin/provisioning_keys/show.html.haml
@@ -1,0 +1,8 @@
+%p#notice= notice
+
+%p
+  %b Issued at:
+  = @provisioning_key.created_at || ''
+%p
+  %b Environment:
+  = @provisioning_key.api_env

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -26,6 +26,8 @@
               = link_to 'Access Requests', admin_access_requests_url
             %li
               = link_to 'Tokens', admin_tokens_url
+            %li
+              = link_to 'Provisioning keys', admin_provisioning_keys_url
             - if true
               %li
                 .sign-out

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,9 +1,13 @@
 require 'moj_sso'
 
-# Localhost SSO config
-app_id = ENV.fetch('MOJSSO_ID')
-app_secret = ENV.fetch('MOJSSO_SECRET')
-sso_url = ENV.fetch('MOJSSO_URL', 'http://localhost:5000') # <- default for localhost
+Rails.configuration.auth_enabled = ENV.fetch('AUTH_ENABLED', 'true').downcase != 'false'
+
+if Rails.configuration.auth_enabled
+  # Localhost SSO config
+  app_id = ENV.fetch('MOJSSO_ID')
+  app_secret = ENV.fetch('MOJSSO_SECRET')
+  sso_url = ENV.fetch('MOJSSO_URL', 'http://localhost:5000') # <- default for localhost
+end
 
 unless app_id && app_secret && sso_url
   STDOUT.puts '[WARN] MOJSSO_ID/MOJSSO_SECRET/MOJSSO_URL not configured'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
       patch :revoke, on: :member
     end
     resources :access_requests, except: [:new, :create, :edit, :update]
+
+    resources :provisioning_keys, only: [:index, :new, :create, :show, :destroy]
   end
 
   namespace :api, format: :json do

--- a/spec/controllers/admin/provisioning_keys_controller_spec.rb
+++ b/spec/controllers/admin/provisioning_keys_controller_spec.rb
@@ -1,0 +1,177 @@
+require 'rails_helper'
+
+RSpec.describe Admin::ProvisioningKeysController, type: :controller do
+  # This should return the minimal set of values that should be in the session
+  # in order to pass any filters (e.g. authentication) defined in
+  # Admin::AccessRequestsController. Be sure to keep this updated too.
+
+  let(:empty_session){ {} }
+  let(:valid_session){ {'sso_user' => {}} }
+  let(:admin_session){ {'sso_user' => {'permissions'=> [{'roles' => [ 'admin' ]}]}}}
+
+  let(:provisioning_key_1) { create(:provisioning_key) }
+
+  # This should return the minimal set of attributes required to create a valid
+  # Token. As you add validations to Token, be sure to
+  # adjust the attributes here as well.
+  let(:valid_attributes) {
+    {
+      api_env: 'dev',
+      content: file_fixture('test_provisioner.key').read
+    }
+  }
+
+  let(:invalid_attributes) {
+    {
+      api_env: 'foobar',
+      content: file_fixture('test_provisioner.key').read
+    }
+  }
+
+  let(:bad_key) {
+    {
+      api_env: 'foobar',
+      content: 'abcd1234'
+    }
+  }
+
+  context 'when not logged in' do
+    let(:session){ empty_session }
+
+    describe "GET #index" do
+      it "redirects to /auth/mojsso" do
+        get :index, params: {}, session: session
+        expect( response ).to redirect_to '/auth/mojsso'
+      end
+    end
+
+    describe "GET #new" do
+      it "redirects to /auth/mojsso" do
+        get :new, params: {}, session: session
+        expect( response ).to redirect_to '/auth/mojsso'
+      end
+    end
+
+    describe "GET #show" do
+      it "redirects to /auth/mojsso" do
+        get :show, params: {id: provisioning_key_1.to_param}, session: session
+        expect( response ).to redirect_to '/auth/mojsso'
+      end
+    end
+
+    describe "POST create" do
+      it "redirects to /auth/mojsso" do
+        post :create, params: {provisioning_key: valid_attributes}, session: session
+        expect( response ).to redirect_to '/auth/mojsso'
+      end
+    end
+  end
+
+  context 'when logged in' do
+    context 'as a user without admin role' do
+      let(:session){ valid_session }
+
+      describe "GET #index" do
+        it "responds with 403" do
+          get :index, params: {}, session: session
+          expect( response.status ).to eq(403)
+        end
+      end
+
+      describe "GET #new" do
+        it "responds with 403" do
+          get :new, params: {}, session: session
+          expect( response.status ).to eq(403)
+        end
+      end
+
+      describe "GET #show" do
+        it "responds with 403" do
+          get :show, params: {id: provisioning_key_1.to_param}, session: session
+          expect( response.status ).to eq(403)
+        end
+      end
+
+      describe "POST create" do
+        it "responds with 403" do
+          post :create, params: {provisioning_key: valid_attributes}, session: session
+          expect( response.status ).to eq(403)
+        end
+      end
+    end
+
+    context 'as a user with admin role' do
+      let(:session){ admin_session }
+
+      describe "GET #index" do
+        it "assigns all provisioning keys to @provisioning_keys" do
+          get :index, params: {}, session: session
+          expect(assigns(:provisioning_keys)).to eq([provisioning_key_1])
+        end
+      end
+
+      describe "GET #new" do
+        it "assigns a new provisioning_key to @provisioning_key" do
+          get :new, params: {}, session: session
+          expect(assigns(:provisioning_key)).to be_a_new(ProvisioningKey)
+        end
+      end
+
+      describe "GET #show" do
+        it "assigns the requested token as @token" do
+          get :show, params: {id: provisioning_key_1.to_param}, session: session
+          expect(assigns(:provisioning_key)).to eq(provisioning_key_1)
+        end
+      end
+
+      describe "DELETE #destroy" do
+        it "destroys the requested provisioning_key" do
+          post :create, params: {provisioning_key: valid_attributes}, session: session
+          expect(ProvisioningKey.count).to be(1)
+          provisioning_key_2 = assigns(:provisioning_key)
+          delete :destroy, params: {id: provisioning_key_2.to_param}, session: session
+          expect(ProvisioningKey.count).to be(0)
+        end
+
+        it "redirects to the provisioning_key list" do
+          delete :destroy, params: {id: provisioning_key_1.to_param}, session: session
+          expect(response).to redirect_to(admin_provisioning_keys_url)
+        end
+      end
+
+      context "with valid params" do
+        it "creates a new ProvisioningKey" do
+          expect {
+            post :create, params: {provisioning_key: valid_attributes}, session: session
+          }.to change(ProvisioningKey, :count).by(1)
+        end
+
+        it "assigns a newly created provisioning_key as @provisioning_key and persists it" do
+          post :create, params: {provisioning_key: valid_attributes}, session: session
+          expect(assigns(:provisioning_key)).to be_a(ProvisioningKey)
+          expect(assigns(:provisioning_key)).to be_persisted
+        end
+
+        it "redirects to the created provisioning_key" do
+          post :create, params: {provisioning_key: valid_attributes}, session: session
+          expect(response).to redirect_to(admin_provisioning_key_url(assigns(:provisioning_key)))
+        end
+      end
+
+      context "with invalid params" do
+        it "assigns a newly created but unsaved provisioning_key as @provisioning_key" do
+          post :create, params: {provisioning_key: invalid_attributes}, session: session
+          expect(assigns(:provisioning_key)).to be_a_new(ProvisioningKey)
+        end
+
+        it "re-renders the 'new' template" do
+          post :create, params: {provisioning_key: invalid_attributes}, session: session
+          expect(response).to render_template("new")
+        end
+      end
+
+    end
+
+  end
+
+end

--- a/spec/factories/provisioning_keys.rb
+++ b/spec/factories/provisioning_keys.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :provisioning_key, class: ProvisioningKey do
+    api_env 'preprod'
+    content { File.read("#{Rails.root}/spec/fixtures/files/test_provisioner.key") }
+  end
+end

--- a/spec/models/provisioning_key_spec.rb
+++ b/spec/models/provisioning_key_spec.rb
@@ -6,4 +6,6 @@ RSpec.describe ProvisioningKey, type: :model do
   it { should validate_inclusion_of(:api_env).in_array(ApiEnv.all) }
   it { should validate_uniqueness_of(:api_env) }
   it { should validate_uniqueness_of(:content) }
+
+  it_behaves_like 'an EC Private Key validatable'
 end

--- a/spec/support/ec_private_key_validatable.rb
+++ b/spec/support/ec_private_key_validatable.rb
@@ -1,0 +1,48 @@
+shared_examples 'an EC Private Key validatable' do |attribute_name: :content|
+  let(:ec_private_key_validatable) { build(described_class.to_s.underscore.to_sym) }
+  let(:ec_public_key) { file_fixture('test_client.pub').read }
+  let(:ec_private_key) { file_fixture('test_client.key').read }
+
+  describe 'validation' do
+    context 'when the the property is a valid EC private key' do
+      it 'is valid' do
+        ec_private_key_validatable.content = ec_private_key
+        ec_private_key_validatable.valid?
+
+        expect(ec_private_key_validatable).to be_valid
+      end
+    end
+
+    context 'when the the property is not a valid EC private key' do
+      context 'is public EC key' do
+        before do
+          ec_private_key_validatable.content = ec_public_key
+          ec_private_key_validatable.valid?
+        end
+
+        it 'is a valid EC key but not a private key' do
+          expect(ec_private_key_validatable).to_not be_valid
+        end
+
+        it 'adds a validation error when not valid' do
+          expect(ec_private_key_validatable.errors[attribute_name]).to include('is not a EC private key')
+        end
+      end
+
+      context 'is not valid' do
+        before do
+          ec_private_key_validatable.content = 'foobar'
+          ec_private_key_validatable.valid?
+        end
+
+        it 'is not valid when the the property is not a valid EC private key' do
+          expect(ec_private_key_validatable).to_not be_valid
+        end
+
+        it 'adds a validation error when not valid' do
+          expect(ec_private_key_validatable.errors[attribute_name]).to include('is not a valid EC private key')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Provisioning keys CRUD MVP so we can upload our existing provisioning keys and generate tokens.
Extra: switch to enable/disable authentication

## How to review

* Run tests
* Create provisioning key
* Check you can't create or invalid duplicate keys
* Look a README and check you can disable authentication