### PR TITLE
change the visible app name to NOMIS API Access

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Build Status](https://travis-ci.org/ministryofjustice/noms-api-gateway-management.svg?branch=master)](https://travis-ci.org/ministryofjustice/noms-api-gateway-management)
 
 # NOMS API Gateway Management
+### AKA "NOMS API Access"
 
 Admin/management tool for the [NOMS API Gateway](https://github.com/ministryofjustice/noms-api-gateway). Facilitates the provisioning, tracking and revocation of client tokens for the NOMIS API.
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -19,7 +19,7 @@
       = link_to 'Menu', '#proposition-links', class: 'js-header-toggle menu'
 
       %nav{ class: "proposition-menu" }
-        = link_to 'API Gateway Management', root_url, id: 'proposition-name'
+        = link_to 'NOMIS API Access', root_url, id: 'proposition-name'
         - if controller_path.split('/').first == 'admin'
           %ul#proposition-links
             %li

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,5 @@
 ---
 applications:
-- name: noms-api-gateway-management
+- name: noms-api-access
   memory: 256M
   buildpack: ruby_buildpack


### PR DESCRIPTION
We've agreed that a better public-facing name for the app is NOMIS API Access.
This PR changes the visible names & URLs to that.

We should probably rename the repo as well, for consistency, but that doesn't need to be right now.
