### PR TITLE
add rake task to import existing tokens from CSV file

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Development seed data is provided in [db/seeds.rb](https://github.com/ministryof
 
 ### Importing existing tokens
 
-There is a rake task in [lib/tasks/import.rake](https://github.com/ministryofjustice/noms-api-gateway-management/lib/tasks/import.rake) to import tokens from a CSV file. The column mappings were based around the existing [Google spreadsheet of tokens](https://docs.google.com/spreadsheets/d/1PJHdykrJ1e7nsm0_07vksy6DbVLzjwHuDAkbwt88y3Q/edit#gid=0) - if you need to change them, you can alter the *from_csv_row* method in [app/models/token.rb](https://github.com/ministryofjustice/noms-api-gateway-management/app/models/token.rb)
+There is a rake task in [lib/tasks/import.rake](https://github.com/ministryofjustice/noms-api-gateway-management/lib/tasks/import.rake) to import tokens from a CSV file. The column mappings were based around the existing [Google spreadsheet of tokens](https://docs.google.com/spreadsheets/d/1PJHdykrJ1e7nsm0_07vksy6DbVLzjwHuDAkbwt88y3Q/edit#gid=0) - if you need to change them, you can alter the *mapped_csv_values* method in [app/models/imported_token_builder.rb](https://github.com/ministryofjustice/noms-api-gateway-management/app/models/imported_token_builder.rb)
 
 To run the task:
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ Development seed data is provided in [db/seeds.rb](https://github.com/ministryof
     rake db:create db:migrate db:seed
     rails s
 
+
+### Importing existing tokens
+
+There is a rake task in [lib/tasks/import.rake](https://github.com/ministryofjustice/noms-api-gateway-management/lib/tasks/import.rake) to import tokens from a CSV file. The column mappings were based around the existing [Google spreadsheet of tokens](https://docs.google.com/spreadsheets/d/1PJHdykrJ1e7nsm0_07vksy6DbVLzjwHuDAkbwt88y3Q/edit#gid=0) - if you need to change them, you can alter the *from_csv_row* method in [app/models/token.rb](https://github.com/ministryofjustice/noms-api-gateway-management/app/models/token.rb)
+
+To run the task:
+
+    rake import:tokens FILE=/path/to/the/csv/file/here
+
+The import is surrounded in a transaction - either all the rows import successfully, or the whole operation rolls back and no changes are made.
+
+
 ### Disable authentication
 
 It is possible to disable authentication for development and testing:

--- a/app/controllers/admin/tokens_controller.rb
+++ b/app/controllers/admin/tokens_controller.rb
@@ -26,6 +26,10 @@ class Admin::TokensController < Admin::AdminController
   # POST /tokens
   def create
     @token = Token.new(token_params)
+    # Explicitly set this here, rather than allow it to be passed in,
+    # as if this value is not 'web', some validations are bypassed
+    # to allow import of incomplete data from old spreadsheet
+    @token.created_from = 'web'
     @access_request = AccessRequest.find(params[:access_request_id]) rescue nil
 
     if @token.save

--- a/app/models/imported_token_builder.rb
+++ b/app/models/imported_token_builder.rb
@@ -1,0 +1,33 @@
+# Builds a valid Token object
+# from a given CSV row.
+class ImportedTokenBuilder
+
+  def self.build(row={})
+    Token.new(
+      mapped_csv_values(row).merge(required_values_not_in_csv)
+    )
+  end
+
+  protected
+
+  def self.mapped_csv_values(row)
+    {
+      api_env: row['NOMS API env'],
+      expires: row['Expiry date'] || Time.now + 1.year, 
+      fingerprint: row['Token fingerprint'],
+      requested_by: row['Requested by'] || '(unknown)',
+      service_name: row['Client name']
+    }
+  end
+
+  def self.required_values_not_in_csv
+    {
+      contact_email: 'unknown',
+      client_pub_key: nil,
+      created_from: 'import',
+      permissions: nil,
+      state: 'active',
+      trackback_token: nil
+    }
+  end
+end

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -1,16 +1,23 @@
 class Token < ApplicationRecord
 
+  CREATED_FROM_VALUES = ['web','import']
+
   attr_accessor :client_pub_key_file
 
-  validates :requested_by, :service_name, :api_env, :expires, :contact_email,
-    :client_pub_key, :permissions, presence: :true
+  validates :requested_by, :service_name, :api_env, :expires, :created_from,
+            presence: :true
 
-  validates :client_pub_key, ec_public_key: true
+  validates :client_pub_key, presence: true, ec_public_key: true, if: :from_web?
+  validates :permissions, presence: true, if: :from_web?
+  validates :contact_email, presence: true, if: :from_web?
+  validates_email_format_of :contact_email, if: :from_web?
+
   validates :api_env, inclusion: ApiEnv.all
-  validates_email_format_of :contact_email
+  validates :created_from, inclusion: Token::CREATED_FROM_VALUES
+
 
   before_validation :set_client_pub_key
-  after_create :set_trackback_token
+  after_create :set_trackback_token, if: :from_web?
 
   scope :inactive, -> { where(state: 'inactive') }
   scope :active, -> { where(state: 'active') }
@@ -43,6 +50,31 @@ class Token < ApplicationRecord
     activate!
     output
   end
+
+  def from_web?
+    created_from == 'web'
+  end
+
+  def from_import?
+    created_from == 'import'
+  end
+
+  def self.from_csv_row(row)
+    new( {
+      requested_by: row['Requested by'] || '(unknown)', 
+      api_env: row['NOMS API env'],
+      expires: row['Expiry date'] || Time.now + 1.year, 
+      contact_email: 'unknown',
+      client_pub_key: nil,
+      service_name: row['Client name'],
+      permissions: nil,
+      created_from: 'import',
+      fingerprint: row['Token fingerprint'],
+      state: 'active',
+      trackback_token: nil
+    } )
+  end
+
 
   private
 

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -59,27 +59,12 @@ class Token < ApplicationRecord
     created_from == 'import'
   end
 
-  def self.from_csv_row(row)
-    new( {
-      requested_by: row['Requested by'] || '(unknown)', 
-      api_env: row['NOMS API env'],
-      expires: row['Expiry date'] || Time.now + 1.year, 
-      contact_email: 'unknown',
-      client_pub_key: nil,
-      service_name: row['Client name'],
-      permissions: nil,
-      created_from: 'import',
-      fingerprint: row['Token fingerprint'],
-      state: 'active',
-      trackback_token: nil
-    } )
-  end
-
-
   private
 
   def set_client_pub_key
-    self.client_pub_key = self.client_pub_key_file.read if self.client_pub_key_file.present?
+    if self.client_pub_key_file.present?
+      self.client_pub_key = self.client_pub_key_file.read
+    end
   end
 
   def set_trackback_token

--- a/app/services/import_tokens.rb
+++ b/app/services/import_tokens.rb
@@ -1,0 +1,40 @@
+module ImportTokens
+  module_function
+
+  def call(csv_filepath)
+    raise ArgumentError, "csv_filepath does not exist: '#{csv_filepath}'" unless File.exists?(csv_filepath)
+
+    data = parse_csv_file(csv_filepath)
+    import_data_in_transaction(data)
+  end
+
+
+  def parse_csv_file(csv_filepath)
+    data = CSV.read(File.expand_path(csv_filepath), headers: true)
+    puts "read #{data.size} rows"
+    data
+  end
+
+  def import_data_in_transaction(data)
+    ActiveRecord::Base.transaction do |t|
+      new_token_count = run_import(data)
+      puts "All done - imported #{new_token_count} tokens"
+    end
+  end
+
+  def run_import(rows)
+    new_tokens = 0
+
+    rows.each_with_index do |row, index|
+      puts "importing row #{index} (#{row.to_s})"
+      import_row!(row)
+      new_tokens = new_tokens + 1
+    end
+    new_tokens
+  end
+
+  def import_row!(row)
+    token = ImportedTokenBuilder.build(row)
+    token.save!
+  end
+end

--- a/db/migrate/20170704091532_add_token_created_from.rb
+++ b/db/migrate/20170704091532_add_token_created_from.rb
@@ -1,0 +1,5 @@
+class AddTokenCreatedFrom < ActiveRecord::Migration[5.0]
+  def change
+    add_column Token, :created_from, :string, default: 'web'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170619135612) do
+ActiveRecord::Schema.define(version: 20170704091532) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 20170619135612) do
     t.text     "permissions"
     t.datetime "created_at",                           null: false
     t.datetime "updated_at",                           null: false
+    t.string   "created_from",    default: "web"
     t.index ["trackback_token"], name: "index_tokens_on_trackback_token", using: :btree
   end
 

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,0 +1,25 @@
+require 'csv'
+
+
+
+namespace :import do
+
+  desc 'Task: import tokens from .csv FILE'
+  task tokens: :environment do
+    file = ENV['FILE']
+    raise "FILE is required" unless file.present?
+    data = CSV.read(File.expand_path(file), headers: true)
+    puts "read #{data.size} rows"
+    tokens = 0
+
+    ActiveRecord::Base.transaction do |t|
+      data.each_with_index do |row, index|
+        puts "importing row #{index} (#{row.to_s})"
+        token = Token.from_csv_row(row)
+        token.save!
+        tokens = tokens + 1
+      end
+    end
+    puts "All done - imported #{tokens} tokens"
+  end
+end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,25 +1,11 @@
 require 'csv'
 
-
-
 namespace :import do
 
   desc 'Task: import tokens from .csv FILE'
   task tokens: :environment do
     file = ENV['FILE']
     raise "FILE is required" unless file.present?
-    data = CSV.read(File.expand_path(file), headers: true)
-    puts "read #{data.size} rows"
-    tokens = 0
-
-    ActiveRecord::Base.transaction do |t|
-      data.each_with_index do |row, index|
-        puts "importing row #{index} (#{row.to_s})"
-        token = Token.from_csv_row(row)
-        token.save!
-        tokens = tokens + 1
-      end
-    end
-    puts "All done - imported #{tokens} tokens"
+    ImportTokens.call(file)
   end
 end

--- a/spec/models/token_spec.rb
+++ b/spec/models/token_spec.rb
@@ -26,38 +26,6 @@ RSpec.describe Token, type: :model do
     it { should_not validate_presence_of(:client_pub_key) }
     it { should_not validate_presence_of(:permissions) }
   end
-    
-  #   describe 'an otherwise valid Token' do
-  #     before do
-  #       subject.requested_by = 'Dave'
-  #       subject.service_name = 'Thingumizer'
-  #       subject.api_env = 'dev'
-  #       subject.expires = Time.now + 1.year
-  #       subject.contact_email = 'al@example.com'
-  #       subject.permissions = '.*'
-  #     end
-
-  #     context 'with no contact_email ' do
-  #       before { subject.contact_email = nil }
-  #       it "is still valid" do
-  #         expect(subject.valid?).to eq(true)
-  #       end
-  #     end
-  #     context 'with no client_pub_key ' do
-  #       before { subject.client_pub_key = nil }
-  #       it "is still valid" do
-  #         expect(subject.valid?).to eq(true)
-  #       end
-  #     end
-  #     context 'with no permissions ' do
-  #       before { subject.permissions = nil }
-  #       it "is still valid" do
-  #         expect(subject.valid?).to eq(true)
-  #       end
-  #     end
-  #   end
-  # end
-  
 
   describe 'scopes' do
     let(:inactive_token) { create(:token) }


### PR DESCRIPTION
Now that we are ready to go live on this app, we need a way to
import the existing, previously issued tokens from the current
csv file.

This commit adds a rake task (rake import:tokens FILE=/path/to/file)
to do that. There were some issues around validations, as some of the
data in the existing Google doc is incomplete, yet we still need
those tokens imported. To make this work, I have:

- added a created_from field to the Token model ('web' or 'import')
- made some of the Token validations conditional on that value.