### PR TITLE
Access request rejection notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ Protection against DDoS and bots on the user facing access request form is provi
 |API_AUTH                               |shared secret used to authenticate against the /api/tokens/revoked endpoint|-|-|-|
 |ACCESS_REQUEST_NOTIFICATION_TEMPLATE   |access request template ID|-|-|-|
 |TOKEN_TRACKBACK_TEMPLATE               |token creation template ID|-|-|-|
+|REJECT_ACCESS_REQUEST_TEMPLATE         |access request rejection template ID|-|-|-|
 |TEAM_EMAIL                             |email address of the product/support team|-|-|-|
 |RECAPTCHA_SITE_KEY                     |Google reCAPTCHA key|-|-|-|
 |RECAPTCHA_SECRET_KEY                   |Google reCAPTCHA secret|-|-|-|
-
 
 ### Set up and run
 

--- a/app/controllers/admin/access_requests_controller.rb
+++ b/app/controllers/admin/access_requests_controller.rb
@@ -13,6 +13,9 @@ class Admin::AccessRequestsController < Admin::AdminController
   # DELETE /access_requests/1
   def destroy
     @access_request.destroy
+
+    Notify.reject_access_request(@access_request) if Rails.configuration.notify_enabled
+
     redirect_to admin_access_requests_url, notice: 'Access request was successfully destroyed.'
   end
 

--- a/app/services/notify.rb
+++ b/app/services/notify.rb
@@ -3,8 +3,6 @@ require 'notifications/client'
 module Notify
   module_function
 
-  CLIENT = Notifications::Client.new(Rails.configuration.govuk_notify_api_key)
-
   def service_team(access_request, link)
     params = {
       requester: access_request.requested_by,
@@ -35,12 +33,16 @@ module Notify
   end
 
   def send_notify_email(email_address, template_id, params = {})
-    email = CLIENT.send_email(
+    email = client.send_email(
       email_address: email_address,
       template_id: template_id,
       personalisation: params
     )
 
     email.id
+  end
+
+  def client
+    Notifications::Client.new(Rails.configuration.govuk_notify_api_key)
   end
 end

--- a/app/services/notify.rb
+++ b/app/services/notify.rb
@@ -4,33 +4,41 @@ module Notify
   module_function
 
   CLIENT = Notifications::Client.new(Rails.configuration.govuk_notify_api_key)
-  ACCESS_REQUEST_NOTIFICATION_TEMPLATE = Rails.configuration.access_request_notification_template
-  TOKEN_TRACKBACK_TEMPLATE = Rails.configuration.token_trackback_template
-  TEAM_EMAIL = Rails.configuration.team_email
 
   def service_team(access_request, link)
-    email = CLIENT.send_email(
-      email_address: TEAM_EMAIL,
-      template_id: ACCESS_REQUEST_NOTIFICATION_TEMPLATE,
-      personalisation: {
-        requester: access_request.requested_by,
-        env: access_request.api_env,
-        access_request_link: link
-      }
-    )
+    params = {
+      requester: access_request.requested_by,
+      env: access_request.api_env,
+      access_request_link: link
+    }
 
-    email.id
+    send_notify_email(Rails.configuration.team_email, Rails.configuration.access_request_notification_template, params)
   end
 
   def token_trackback(token, link)
+    params = {
+      requester: token.requested_by,
+      env: token.api_env,
+      trackback_link: link
+    }
+
+    send_notify_email(token.contact_email, Rails.configuration.token_trackback_template, params)
+  end
+
+  def reject_access_request(access_request)
+    params = {
+      requester: access_request.requested_by,
+      env: access_request.api_env
+    }
+
+    send_notify_email(access_request.contact_email, Rails.configuration.reject_access_request_template)
+  end
+
+  def send_notify_email(email_address, template_id, params = {})
     email = CLIENT.send_email(
-      email_address: token.contact_email,
-      template_id: TOKEN_TRACKBACK_TEMPLATE,
-      personalisation: {
-        requester: token.requested_by,
-        env: token.api_env,
-        trackback_link: link
-      }
+      email_address: email_address,
+      template_id: template_id,
+      personalisation: params
     )
 
     email.id

--- a/config/initializers/notify.rb
+++ b/config/initializers/notify.rb
@@ -3,4 +3,5 @@ Rails.configuration.notify_enabled = ENV.fetch('NOTIFY_ENABLED', 'true').downcas
 Rails.configuration.govuk_notify_api_key = ENV.fetch('GOVUK_NOTIFY_API_KEY', '')
 Rails.configuration.access_request_notification_template = ENV.fetch('ACCESS_REQUEST_NOTIFICATION_TEMPLATE', '8daffa73-f7df-4494-8df5-ce737b52ae86')
 Rails.configuration.token_trackback_template = ENV.fetch('TOKEN_TRACKBACK_TEMPLATE', 'e39fd6e3-cdcd-4396-8632-3d733f2653b3')
+Rails.configuration.reject_access_request_template = ENV.fetch('REJECT_ACCESS_REQUEST_TEMPLATE', 'd39e6478-17d5-4f51-be08-752d413e4633')
 Rails.configuration.team_email = ENV.fetch('TEAM_EMAIL', 'nomisapi@digital.justice.gov.uk')

--- a/spec/controllers/access_requests_controller_spec.rb
+++ b/spec/controllers/access_requests_controller_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe AccessRequestsController, type: :controller do
   describe "POST #create" do
     before do
       response = double(id: 'f23caa')
-      allow(Notify::CLIENT).to receive(:send_email).and_return(response)
+      allow(Notify.client).to receive(:send_email).and_return(response)
     end
 
     context "with valid params" do

--- a/spec/controllers/admin/access_requests_controller_spec.rb
+++ b/spec/controllers/admin/access_requests_controller_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Admin::AccessRequestsController, type: :controller do
       describe "DELETE #destroy" do
         before do
           response = double(id: 'f23caa')
-          allow(Notify::CLIENT).to receive(:send_email).and_return(response)
+          allow(Notify.client).to receive(:send_email).and_return(response)
         end
 
         it "destroys the requested access_request" do

--- a/spec/controllers/admin/access_requests_controller_spec.rb
+++ b/spec/controllers/admin/access_requests_controller_spec.rb
@@ -80,6 +80,11 @@ RSpec.describe Admin::AccessRequestsController, type: :controller do
       end
 
       describe "DELETE #destroy" do
+        before do
+          response = double(id: 'f23caa')
+          allow(Notify::CLIENT).to receive(:send_email).and_return(response)
+        end
+
         it "destroys the requested access_request" do
           access_request
 

--- a/spec/controllers/admin/tokens_controller_spec.rb
+++ b/spec/controllers/admin/tokens_controller_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe Admin::TokensController, type: :controller do
     describe "POST #create" do
       before do
         response = double(id: 'f23caa')
-        allow(Notify::CLIENT).to receive(:send_email).and_return(response)
+        allow(Notify.client).to receive(:send_email).and_return(response)
       end
 
       context "with valid params" do

--- a/spec/services/notify_spec.rb
+++ b/spec/services/notify_spec.rb
@@ -26,4 +26,16 @@ RSpec.describe Notify do
       expect(Notify.token_trackback(token, trackback_token)).to eq('96f063d1-996d-43ed-9253-6a32c423faaf')
     end
   end
+
+  describe '#reject_access_request' do
+    let(:access_request) { create(:access_request) }
+
+    before do
+      allow(Notify).to receive(:reject_access_request).with(access_request).and_return('36f043d1-956c-43ed-9253-6a32c423fbbf')
+    end
+
+    it 'sends a request to GOV UK Notify and returns the notification id' do
+      expect(Notify.reject_access_request(access_request)).to eq('36f043d1-956c-43ed-9253-6a32c423fbbf')
+    end
+  end
 end


### PR DESCRIPTION
GOV.UK Notify rejection notification email sent when access request rejected. 

Template: https://www.notifications.service.gov.uk/services/5392791f-a1e4-49d4-b51e-f1c624ab2872/templates/d39e6478-17d5-4f51-be08-752d413e4633

Env var needs to be set to template_id found.
