### PR TITLE
Fix error in (token/access_request) show.html.haml when env is deleted

### DIFF
--- a/app/views/admin/access_requests/show.html.haml
+++ b/app/views/admin/access_requests/show.html.haml
@@ -18,7 +18,7 @@
 
 %p
   %b API environment:
-  = @access_request.environment.name
+  = @access_request.environment_name
 
 %p
   %b Client public key:

--- a/app/views/admin/tokens/show.html.haml
+++ b/app/views/admin/tokens/show.html.haml
@@ -19,7 +19,7 @@
   = @token.fingerprint
 %p
   %b Api env:
-  = @token.environment.name
+  = @token.environment_name
 
 %p
   %b Permissions:


### PR DESCRIPTION
- token.environment.name and access_request.environment.name will fail if environment has been deleted
- This was fixed for index views but not for show
- Now using #environment_name instead, which can handle the nulled environment for token and access_request