### PR TITLE
Fix migration by properly setting keys and token for existing envs

### DIFF
--- a/db/migrate/20170914133947_add_jwt_to_environment.rb
+++ b/db/migrate/20170914133947_add_jwt_to_environment.rb
@@ -3,6 +3,8 @@ class AddJwtToEnvironment < ActiveRecord::Migration[5.0]
     add_column :environments, :jwt, :text
 
     Environment.all.each do |env|
+      env.send(:generate_client_keys)
+      env.send(:generate_jwt)
       env.save!
     end
   end


### PR DESCRIPTION
- Change in the model were not followed up with changes to the migration
- This led to the keys and jwt not being created for existing envs
- Only became apparent on staging, thanks to the smoke test