### PR TITLE
Fixes copy on the token download page

### DIFF
--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -3,6 +3,7 @@ class TokensController < ApplicationController
 
   # GET /tokens/new
   def new
+    @team_email = set_team_email
   end
 
   # PATCH/PUT /tokens/1
@@ -22,5 +23,9 @@ class TokensController < ApplicationController
   def set_token
     @token = Token.find_by(trackback_token: params[:trackback_token])
     raise ActionController::RoutingError.new('Not Found') unless @token
+  end
+
+  def set_team_email
+    ENV['TEAM_EMAIL'] || 'nomisapi@digital.justice.gov.uk'
   end
 end

--- a/app/views/tokens/new.html.haml
+++ b/app/views/tokens/new.html.haml
@@ -1,7 +1,7 @@
 %p#notice= notice
 
 %p
-  Your access token is available for download below. Please note that this is a one time only download link and will expire once downloaded or in X days. If you have any issues please contact X.
+  Your access token is available for download below. Please note that this is a one time only download link and will expire once the token is downloaded. If you have any issues please contact #{ mail_to @team_email }.
 
 = form_for @token do |f|
   = hidden_field_tag :trackback_token, @token.trackback_token


### PR DESCRIPTION
- Previously it said that the link will expire in X days and that they could get info by contacting X
- I've taken out the bit about expiry since we've not yet implemented expiry.
- X for the contact details has been replaced with the team email address, as a mail_to link