### PR TITLE
Fix malformed env.jwt permissions regex

### DIFF
--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -45,7 +45,7 @@ class Environment < ApplicationRecord
       client_pub_key: self.client_pub_key,
       contact_email: nil,
       environment: self,
-      permissions: ["/^\/nomisapi\/version$/","/^\/nomisapi\/health$/"],
+      permissions: "^\/nomisapi\/version$\n^\/nomisapi\/health$",
       created_from: 'management_app'
     )
     self.update_attribute(:jwt, token.provision_and_activate!)


### PR DESCRIPTION
- The permissions for automatically generated JWT on the env model are not formed correctly.
- Somehow they seem to work but, nevertheless, this changes them to the correct format.