### PR TITLE
Show permitted endpoints on token download page

### DIFF
--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -4,6 +4,7 @@ class TokensController < ApplicationController
   # GET /tokens/new
   def new
     @team_email = set_team_email
+    @parsed_permissions = set_parsed_permissions
   end
 
   # PATCH/PUT /tokens/1
@@ -27,5 +28,9 @@ class TokensController < ApplicationController
 
   def set_team_email
     ENV['TEAM_EMAIL'] || 'nomisapi@digital.justice.gov.uk'
+  end
+
+  def set_parsed_permissions
+    @token.permissions.split.map { |p| Regexp.new(p).inspect }
   end
 end

--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -23,7 +23,7 @@ class TokensController < ApplicationController
 
   def set_token
     @token = Token.find_by(trackback_token: params[:trackback_token])
-    raise ActionController::RoutingError.new('Not Found') unless @token
+    raise ActionController::RoutingError.new('Not Found') if params[:trackback_token].blank? || @token.nil?
   end
 
   def set_team_email

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -45,7 +45,7 @@ class Environment < ApplicationRecord
       client_pub_key: self.client_pub_key,
       contact_email: nil,
       environment: self,
-      permissions: "^\/nomisapi\/version$\n^\/nomisapi\/health$",
+      permissions: "^\\/nomisapi\\/version$\n^\\/nomisapi\\/health$",
       created_from: 'management_app'
     )
     self.update_attribute(:jwt, token.provision_and_activate!)

--- a/app/services/provision_token.rb
+++ b/app/services/provision_token.rb
@@ -10,7 +10,7 @@ module ProvisionToken
 
     private_key = OpenSSL::PKey::EC.new(private_key_data)
     client_pub_key = OpenSSL::PKey::EC.new(token.client_pub_key)
-    permissions = token.permissions.split("\n").reject { |l| l.start_with?('#') }
+    permissions = token.permissions.split.reject { |l| l.start_with?('#') }
 
     now = Time.now
     client_token, fingerprint = generate_client_token(

--- a/app/views/tokens/new.html.haml
+++ b/app/views/tokens/new.html.haml
@@ -3,6 +3,13 @@
 %p
   Your access token is available for download below. Please note that this is a one time only download link and will expire once the token is downloaded. If you have any issues please contact #{ mail_to @team_email }.
 
+%p
+  The token encodes your access rights using the following regular expression/s
+
+  %ul
+  - @parsed_permissions.each do |permission|
+    %li= permission
+
 = form_for @token do |f|
   = hidden_field_tag :trackback_token, @token.trackback_token
   = f.submit 'Download', class: 'button'

--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -27,11 +27,13 @@ RSpec.describe TokensController, type: :controller do
 
     context 'without a valid trackback token' do
       it "raises 404" do
-        expect{ get :new, params: { trackback_token: 'xxxx' } }.to raise_exception(ActionController::RoutingError)
+        expect{ get :new, params: { trackback_token: 'xxxx' } }.
+          to raise_exception(ActionController::RoutingError)
       end
     end
 
-    context 'with no trackback token' do
+    context 'with no trackback token, when a token without a trackback_token exists' do
+      before { create(:token, trackback_token: nil) }
       it "raises 404" do
         expect{ get :new }.to raise_exception(ActionController::RoutingError)
       end
@@ -41,7 +43,8 @@ RSpec.describe TokensController, type: :controller do
   describe "PATCH/PUT #update" do
     context 'non valid trackback token' do
       it 'raises 404' do
-        expect{ patch :update, params: { id: token, trackback_token: '123xxx' } }.to raise_exception(ActionController::RoutingError)
+        expect{ patch :update, params: { id: token, trackback_token: '123xxx' } }.
+          to raise_exception(ActionController::RoutingError)
       end
     end
 

--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe TokensController, type: :controller do
 
       it "assigns @team_email" do
         get :new, params: { trackback_token: token.trackback_token }
-        expect(assigns(:team_email)).to eq 'nomisapi@digital.justice.gov.uk'
+        expect(assigns(:team_email)).not_to be_nil
       end
 
       it 'assigns @parsed_permissions' do

--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -1,13 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe TokensController, type: :controller do
-  let(:token) { create(:token) }
+  let(:token) { create(:token, permissions: "^\\/nomisapi\\/foo$\n^\\/nomisapi\\/bar$\r\n^\\/nomisapi\\/baz$") }
 
   describe "GET #new" do
     context 'with a valid trackback token' do
       it "returns http success" do
         get :new, params: { trackback_token: token.trackback_token }
         expect(response).to have_http_status(:success)
+      end
+
+      it "assigns @team_email" do
+        get :new, params: { trackback_token: token.trackback_token }
+        expect(assigns(:team_email)).to eq 'nomisapi@digital.justice.gov.uk'
+      end
+
+      it 'assigns @parsed_permissions' do
+        get :new, params: { trackback_token: token.trackback_token }
+        expect(assigns(:parsed_permissions)).to eq [
+            "/^\\/nomisapi\\/foo$/",
+            "/^\\/nomisapi\\/bar$/",
+            "/^\\/nomisapi\\/baz$/"
+          ]
       end
     end
 


### PR DESCRIPTION
- Grab permissions from the Token object, rather than the JWT, since the latter is only created on download
- Show permissions to user so that they can easily see what they can access (and whether this meets their requirements)
- This also allows the user to verify that the regex are valid!  At the moment, we rely on the admin users not making any errors there (there is no validation).
- Also refactor ProvisionToken service object to split on any newline char (`#split`) defaults to split on either `\n` or `\r\n`