### PR TITLE
Fixes bug where params were not passed to Notify

### DIFF
--- a/app/services/notify.rb
+++ b/app/services/notify.rb
@@ -29,7 +29,7 @@ module Notify
       env: access_request.environment.name
     }
 
-    send_notify_email(access_request.contact_email, Rails.configuration.reject_access_request_template)
+    send_notify_email(access_request.contact_email, Rails.configuration.reject_access_request_template, params)
   end
 
   def send_notify_email(email_address, template_id, params = {})


### PR DESCRIPTION
GOV.UK Notify client was not being passed params for the access request rejection template.