### PR TITLE
Admin can upload new key, if original's invalid

### DIFF
--- a/app/views/admin/tokens/_form.html.haml
+++ b/app/views/admin/tokens/_form.html.haml
@@ -25,18 +25,22 @@
   .field
     = f.text_area :permissions
 
-  - if @token.client_pub_key.present?
+  - if @token.client_pub_key.present? && @token.errors[:client_pub_key].blank?
     %p
     .field
       = f.text_area :client_pub_key, readonly: true, rows: 6
+
   - else
     .field
-      .form-group
+      .form-group{ class: ('form-group-error' if @token.errors[:client_pub_key]).present? }
         = f.label :client_pub_key_file, class: 'form-label' do
           Client public key
           %span.form-hint
             %p
               Supplied by requester.
+        - if @token.errors[:client_pub_key].present?
+          .error-message
+            = "Client pub key " + @token.errors[:client_pub_key].first
         = f.file_field :client_pub_key_file
         = f.hidden_field :client_pub_key, value: @token.client_pub_key
 


### PR DESCRIPTION
- previously the admin user would be shown a a read only text area when the key they uploaded was invalid, so they were unable to edit the value
- this PR allows the invalid key to be replaced with a valid one by selecting a new file
- At the moment FormBuilder does not style file upload buttons and does not automatically add errors to them either.
- Once @aliuk2012 has updated FormBuilder (sometime next week) I can tidy up the `_form` view