### PR TITLE
Update properties asynchronously

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+gem 'delayed_job_active_record'
 gem 'govuk_elements_form_builder', git: 'https://github.com/ministryofjustice/govuk_elements_form_builder.git'
 gem 'govuk_elements_rails'
 gem 'govuk_frontend_toolkit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,11 @@ GEM
       railties (>= 4, < 5.2)
     cucumber-wire (0.0.1)
     database_cleaner (1.6.1)
+    delayed_job (4.1.3)
+      activesupport (>= 3.0, < 5.2)
+    delayed_job_active_record (4.1.2)
+      activerecord (>= 3.0, < 5.2)
+      delayed_job (>= 3.0, < 5)
     diff-lcs (1.3)
     docile (1.1.5)
     domain_name (0.5.20170404)
@@ -335,6 +340,7 @@ DEPENDENCIES
   awesome_print
   cucumber-rails
   database_cleaner
+  delayed_job_active_record
   dotenv-rails
   factory_girl_rails
   faker
@@ -372,4 +378,4 @@ DEPENDENCIES
   web-console
 
 BUNDLED WITH
-   1.15.3
+   1.16.0.pre.3

--- a/app/jobs/update_environment_properties_job.rb
+++ b/app/jobs/update_environment_properties_job.rb
@@ -1,0 +1,11 @@
+class UpdateEnvironmentPropertiesJob < ApplicationJob
+  queue_as :default
+
+  def perform(env)
+    client = NomisApiClient.new(env, ExceptionSafeResponseParser.new)
+    env.update_attribute(:health, client.get_health)
+    env.update_attribute(:deployed_version, client.get_version)
+    env.update_attribute(:deployed_version_timestamp, client.get_version_timestamp)
+    env.update_attribute(:properties_last_checked, DateTime.now)
+  end
+end

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -1,7 +1,7 @@
 class Environment < ApplicationRecord
 
   before_create :generate_client_keys
-  after_create  :generate_jwt
+  after_create  :generate_jwt, :update_properties!
   before_destroy :revoke_all_tokens!
 
   has_many :tokens, dependent: :nullify
@@ -12,17 +12,14 @@ class Environment < ApplicationRecord
 
   validates :provisioning_key, ec_private_key: true
 
-  attr_accessor :pretty_last_checked
-
   def update_properties!
     if properties_last_checked.nil? || properties_stale?
-      client = NomisApiClient.new(self, ExceptionSafeResponseParser.new)
-      update_attribute(:health, client.get_health)
-      update_attribute(:deployed_version, client.get_version)
-      update_attribute(:deployed_version_timestamp, client.get_version_timestamp)
-      update_attribute(:properties_last_checked, DateTime.now)
+      UpdateEnvironmentPropertiesJob.perform_later(self)
     end
-    self.pretty_last_checked = properties_last_checked.strftime("%H:%M")
+  end
+
+  def pretty_last_checked
+    properties_last_checked.strftime("%H:%M") if !properties_last_checked.nil?
   end
 
   private

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -14,7 +14,7 @@ class Environment < ApplicationRecord
 
   def update_properties!
     if properties_last_checked.nil? || properties_stale?
-      UpdateEnvironmentPropertiesJob.perform_later(self)
+      UpdateEnvironmentPropertiesJob.perform_later(self) unless already_queued?
     end
   end
 
@@ -26,6 +26,20 @@ class Environment < ApplicationRecord
 
   def properties_stale?
     properties_last_checked < interval.minutes.ago
+  end
+
+  def already_queued?
+    env_ids_in_queue.include? self.id
+  end
+
+  def env_ids_in_queue
+    queue.map do |job|
+      job.job_data['arguments'].first.values.first.split('/').last.to_i
+    end
+  end
+
+  def queue
+    Delayed::Job.all.map { |job| YAML.load(job.handler) }
   end
 
   def revoke_all_tokens!

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -29,17 +29,7 @@ class Environment < ApplicationRecord
   end
 
   def already_queued?
-    env_ids_in_queue.include? self.id
-  end
-
-  def env_ids_in_queue
-    queue.map do |job|
-      job.job_data['arguments'].first.values.first.split('/').last.to_i
-    end
-  end
-
-  def queue
-    Delayed::Job.all.map { |job| YAML.load(job.handler) }
+    Delayed::Job.env_ids_in_queue.include? self.id
   end
 
   def revoke_all_tokens!

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,8 @@ module NomsApiGatewayManagement
 
     config.time_zone = 'London'
 
+    config.active_job.queue_adapter = :delayed_job
+    
     config.generators do |g|
       g.view_specs false
       g.helper_specs false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
-  # config.active_job.queue_adapter     = :resque
+  # config.active_job.queue_adapter = :delayed_job
   # config.active_job.queue_name_prefix = "noms-api-gateway-management_#{Rails.env}"
   config.action_mailer.perform_caching = false
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,6 +37,9 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
+  # Do not queue jobs in the test env unless specified
+  Delayed::Worker.delay_jobs = false
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -2,7 +2,6 @@ require 'delayed_job'
 
 module Delayed
   class Job
-
     def self.env_ids_in_queue
       queue.map do |job|
         job.job_data['arguments'].first.values.first.split('/').last.to_i
@@ -12,6 +11,5 @@ module Delayed
     def self.queue
       all.map { |job| YAML.load(job.handler) }
     end
-    
   end
 end

--- a/config/initializers/extensions.rb
+++ b/config/initializers/extensions.rb
@@ -1,0 +1,17 @@
+require 'delayed_job'
+
+module Delayed
+  class Job
+
+    def self.env_ids_in_queue
+      queue.map do |job|
+        job.job_data['arguments'].first.values.first.split('/').last.to_i
+      end
+    end
+
+    def self.queue
+      all.map { |job| YAML.load(job.handler) }
+    end
+    
+  end
+end

--- a/db/migrate/20171031144858_create_delayed_jobs.rb
+++ b/db/migrate/20171031144858_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration[5.0]
+  def self.up
+    create_table :delayed_jobs, force: true do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171026154507) do
+ActiveRecord::Schema.define(version: 20171031144858) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,21 @@ ActiveRecord::Schema.define(version: 20171026154507) do
     t.datetime "updated_at",                     null: false
     t.integer  "environment_id"
     t.index ["environment_id"], name: "index_access_requests_on_environment_id", using: :btree
+  end
+
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer  "priority",   default: 0, null: false
+    t.integer  "attempts",   default: 0, null: false
+    t.text     "handler",                null: false
+    t.text     "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string   "locked_by"
+    t.string   "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
   end
 
   create_table "environments", force: :cascade do |t|

--- a/spec/controllers/admin/environments_controller_spec.rb
+++ b/spec/controllers/admin/environments_controller_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe Admin::EnvironmentsController, type: :controller do
     }
   }
 
+  before(:each) do
+    allow_any_instance_of(Environment).to receive(:update_properties!).and_return(nil)
+  end
+
   context 'when not logged in' do
     let(:session){ empty_session }
 

--- a/spec/factories/access_requests.rb
+++ b/spec/factories/access_requests.rb
@@ -7,11 +7,7 @@ FactoryGirl.define do
     client_pub_key { File.read("#{Rails.root}/spec/fixtures/files/test_client.pub") }
     processed false
     environment do
-      Environment.find_or_create_by!(
-        name: 'dev',
-        provisioning_key: File.read("#{Rails.root}/spec/fixtures/files/test_provisioner.key"),
-        base_url: "https://noms-api.TEST.justice.gov.uk/nomisapi/"
-      )
+      create(:environment)
     end
 
     trait :unprocessed do

--- a/spec/factories/environment.rb
+++ b/spec/factories/environment.rb
@@ -1,9 +1,15 @@
 FactoryGirl.define do
   factory :environment, class: Environment do
-    name 'preprod'
+    name 'dev'
     base_url "https://noms-api.TEST.justice.gov.uk/nomisapi/"
+    
     provisioning_key do
       File.read("#{Rails.root}/spec/fixtures/files/test_provisioner.key")
     end
+
+    health 'DB Up'
+    deployed_version '1.0.0'
+    deployed_version_timestamp Time.now
+    properties_last_checked Time.now
   end
 end

--- a/spec/factories/tokens.rb
+++ b/spec/factories/tokens.rb
@@ -16,11 +16,8 @@ FactoryGirl.define do
     client_pub_key pub.to_pem
     state 'inactive'
     environment do
-      Environment.find_or_create_by!(
-        name: 'preprod',
-        provisioning_key: File.read("#{Rails.root}/spec/fixtures/files/test_provisioner.key"),
-        base_url: "https://noms-api.TEST.justice.gov.uk/nomisapi/"
-      )
+      env = Environment.find_by(name: 'dev')
+      env ? env : create(:environment)
     end
 
     trait :inactive do

--- a/spec/jobs/update_environment_properties_job_spec.rb
+++ b/spec/jobs/update_environment_properties_job_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe UpdateEnvironmentPropertiesJob, type: :job do
+
+  let(:client) do
+    double 'NomisApiClient',
+    get_health: 'updated',
+    get_version: '1.0.1',
+    get_version_timestamp: '2017-09-14 09:56:36'
+  end
+
+  let(:environment) do
+    create(
+      :environment,
+      health: 'stale',
+      deployed_version: '0.0.0',
+      deployed_version_timestamp: Time.now
+    )
+  end
+
+  subject { UpdateEnvironmentPropertiesJob.new(environment) }
+
+  before do
+    Delayed::Worker.delay_jobs = false
+    allow(NomisApiClient).to receive(:new).and_return(client)
+  end
+
+  it 'sets #health' do
+    subject.perform_now
+    expect(environment.health).to eq 'updated'
+  end
+
+  it 'sets #deployed_version' do
+    subject.perform_now
+    expect(environment.deployed_version).to eq '1.0.1'
+  end
+
+  it 'sets #deployed_version_timestamp' do
+    subject.perform_now
+    expect(environment.deployed_version_timestamp.to_s).to eq '2017-09-14 09:56:36 +0100'
+  end
+end

--- a/spec/models/environment_spec.rb
+++ b/spec/models/environment_spec.rb
@@ -114,5 +114,17 @@ RSpec.describe Environment, type: :model do
         expect{ subject.update_properties! }.to change{ Delayed::Job.count }.by 0
       end
     end
+
+    context 'when a job is already queued' do
+
+      before { allow(subject).to receive(:properties_stale?).and_return true }
+
+      it 'does not queue another job' do
+        subject.update_properties!
+        expect(Delayed::Job.count).to eq 1
+        subject.update_properties!
+        expect(Delayed::Job.count).to eq 1
+      end
+    end
   end
 end

--- a/spec/models/environment_spec.rb
+++ b/spec/models/environment_spec.rb
@@ -75,39 +75,21 @@ RSpec.describe Environment, type: :model do
     end
   end
 
-  let(:client) do
-    double 'NomisApiClient',
-    get_health: 'DB Up',
-    get_version: '1.0.1',
-    get_version_timestamp: '2017-09-14 09:56:36'
-  end
-
   describe '#update_properties!' do
-    context 'When an env has just been created' do
-      it 'instantiates a NomisApiClient' do
-        expect(NomisApiClient).to receive(:new).and_return(client)
-        subject.update_properties!
-      end
 
-      before { allow(NomisApiClient).to receive(:new).and_return(client) }
+    before do
+      Delayed::Worker.delay_jobs = true
+    end
 
-      it 'sets #health' do
-        subject.update_properties!
-        expect(subject.health).to eq 'DB Up'
-      end
-
-      it 'sets #deployed_version' do
-        subject.update_properties!
-        expect(subject.deployed_version).to eq '1.0.1'
-      end
-
-      it 'sets #deployed_version_timestamp' do
-        subject.update_properties!
-        expect(subject.deployed_version_timestamp.to_s).to eq '2017-09-14 09:56:36 +0100'
+    context 'Called after_create' do
+      it 'enqueues an UpdateEnvironmentProperties job' do
+        expect{
+          create(:environment, properties_last_checked: nil)
+        }.to change{ Delayed::Job.count }.by 1
       end
     end
 
-    context 'When the values for properties are stale' do
+    context 'Called when properties are stale' do
       before do
         subject.health = 'Foo'
         subject.deployed_version = '1.0.0'
@@ -115,30 +97,12 @@ RSpec.describe Environment, type: :model do
         subject.properties_last_checked = 11.minutes.ago
       end
 
-      it 'instantiates a NomisApiClient' do
-        expect(NomisApiClient).to receive(:new).and_return(client)
-        subject.update_properties!
-      end
-
-      before { allow(NomisApiClient).to receive(:new).and_return(client) }
-
-      it 'sets #health' do
-        subject.update_properties!
-        expect(subject.health).to eq 'DB Up'
-      end
-
-      it 'sets #deployed_version' do
-        subject.update_properties!
-        expect(subject.deployed_version).to eq '1.0.1'
-      end
-
-      it 'sets #deployed_version_timestamp' do
-        subject.update_properties!
-        expect(subject.deployed_version_timestamp.to_s).to eq '2017-09-14 09:56:36 +0100'
+      it 'enqueues an UpdateEnvironmentProperties job' do
+        expect{ subject.update_properties! }.to change{ Delayed::Job.count }.by 1
       end
     end
 
-    context 'When the properties have been recently updated' do
+    context 'Called when properties have been recently updated' do
       before do
         subject.health = 'Foo'
         subject.deployed_version = '1.0.2'
@@ -146,26 +110,8 @@ RSpec.describe Environment, type: :model do
         subject.properties_last_checked = 9.minutes.ago
       end
 
-      it 'does not instantiate a new NomisApiClient' do
-        expect(NomisApiClient).not_to receive(:new)
-        subject.update_properties!
-      end
-
-      before { allow(NomisApiClient).to receive(:new).and_return(client) }
-
-      it 'does not update #health' do
-        subject.update_properties!
-        expect(subject.health).to eq 'Foo'
-      end
-
-      it 'does not change #deployed_version' do
-        subject.update_properties!
-        expect(subject.deployed_version).to eq '1.0.2'
-      end
-
-      it 'does not change #deployed_version_timestamp' do
-        subject.update_properties!
-        expect(subject.deployed_version_timestamp.to_s).to eq 1.day.ago.to_s
+      it 'does not enqueue an UpdateEnvironmentProperties job' do
+        expect{ subject.update_properties! }.to change{ Delayed::Job.count }.by 0
       end
     end
   end

--- a/spec/models/token_spec.rb
+++ b/spec/models/token_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Token, type: :model do
     context 'when environment is present' do
       before { subject.environment = create(:environment) }
       it 'returns the environment name' do
-        expect(subject.environment_name).to eq 'preprod'
+        expect(subject.environment_name).to eq 'dev'
       end
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -79,6 +79,10 @@ RSpec.configure do |config|
       example.run
     end
   end
+
+  config.after(:each) do
+    Delayed::Job.destroy_all
+  end
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/services/retrieve_key_spec.rb
+++ b/spec/services/retrieve_key_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe RetrieveKey do
 
     it 'returns the key content for the given API env' do
       create(:environment)
-      expect( described_class.call('preprod') ).to eq(file_fixture('test_provisioner.key').read)
+      expect( described_class.call('dev') ).to eq(file_fixture('test_provisioner.key').read)
     end
-
   end
 end


### PR DESCRIPTION
- To avoid long loading times on the environments index view
- Update is performed using DelayedJob out of process
- Need to stub the call to #update_properties! in some tests because it's now on an after_create hook as well as in EnvironmentsController