### PR TITLE
Re-implement: Update properties asynchronously

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+gem 'daemons'
+gem 'delayed_job_active_record'
 gem 'govuk_elements_form_builder', git: 'https://github.com/ministryofjustice/govuk_elements_form_builder.git'
 gem 'govuk_elements_rails'
 gem 'govuk_frontend_toolkit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,13 @@ GEM
       nokogiri (~> 1.5)
       railties (>= 4, < 5.2)
     cucumber-wire (0.0.1)
+    daemons (1.2.5)
     database_cleaner (1.6.1)
+    delayed_job (4.1.3)
+      activesupport (>= 3.0, < 5.2)
+    delayed_job_active_record (4.1.2)
+      activerecord (>= 3.0, < 5.2)
+      delayed_job (>= 3.0, < 5)
     diff-lcs (1.3)
     docile (1.1.5)
     domain_name (0.5.20170404)
@@ -334,7 +340,9 @@ PLATFORMS
 DEPENDENCIES
   awesome_print
   cucumber-rails
+  daemons
   database_cleaner
+  delayed_job_active_record
   dotenv-rails
   factory_girl_rails
   faker
@@ -372,4 +380,4 @@ DEPENDENCIES
   web-console
 
 BUNDLED WITH
-   1.15.3
+   1.16.0.pre.3

--- a/app/jobs/update_environment_properties_job.rb
+++ b/app/jobs/update_environment_properties_job.rb
@@ -1,0 +1,13 @@
+class UpdateEnvironmentPropertiesJob < ApplicationJob
+  queue_as :default
+
+  def perform(env)
+    client = NomisApiClient.new(env, ExceptionSafeResponseParser.new)
+    env.update_attributes(
+      health: client.get_health,
+      deployed_version: client.get_version,
+      deployed_version_timestamp: client.get_version_timestamp,
+      properties_last_checked: DateTime.now
+    )
+  end
+end

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -30,3 +30,9 @@ if [ "${NOTIFY_ENABLED:-true}" = "true" ]; then
 fi
 
 cf start "${CF_APP_NAME}"
+
+echo Deploying nomis-api-delayed-job
+
+cf push --no-start -f manifest_delayed_job.yml "${CF_JOB_APP_NAME}"
+cf bind-service "${CF_JOB_APP_NAME}" "${CF_DB_NAME}"
+cf start "${CF_JOB_APP_NAME}"

--- a/ci/push.sh
+++ b/ci/push.sh
@@ -8,4 +8,5 @@ docker run -v "${SCRIPT_DIR}"/..:/app -w /app \
   -e NOTIFY_ENABLED -e GOVUK_NOTIFY_API_KEY \
   -e MOJSSO_ID -e MOJSSO_SECRET -e MOJSSO_URL \
   -e API_AUTH \
+  -e CF_JOB_APP_NAME -e CF_DB_NAME \
   governmentpaas/cf-cli ci/deploy.sh

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,8 @@ module NomsApiGatewayManagement
 
     config.time_zone = 'London'
 
+    config.active_job.queue_adapter = :delayed_job
+    
     config.generators do |g|
       g.view_specs false
       g.helper_specs false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
-  # config.active_job.queue_adapter     = :resque
+  # config.active_job.queue_adapter = :delayed_job
   # config.active_job.queue_name_prefix = "noms-api-gateway-management_#{Rails.env}"
   config.action_mailer.perform_caching = false
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,6 +37,9 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
+  # Do not queue jobs in the test env unless specified
+  Delayed::Worker.delay_jobs = false
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,0 +1,15 @@
+require 'delayed_job'
+
+module Delayed
+  class Job
+    def self.env_ids_in_queue
+      queue.map do |job|
+        job.job_data['arguments'].first.values.first.split('/').last.to_i
+      end
+    end
+
+    def self.queue
+      all.map { |job| YAML.load(job.handler) }
+    end
+  end
+end

--- a/db/migrate/20171031144858_create_delayed_jobs.rb
+++ b/db/migrate/20171031144858_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration[5.0]
+  def self.up
+    create_table :delayed_jobs, force: true do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171026154507) do
+ActiveRecord::Schema.define(version: 20171031144858) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,21 @@ ActiveRecord::Schema.define(version: 20171026154507) do
     t.datetime "updated_at",                     null: false
     t.integer  "environment_id"
     t.index ["environment_id"], name: "index_access_requests_on_environment_id", using: :btree
+  end
+
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer  "priority",   default: 0, null: false
+    t.integer  "attempts",   default: 0, null: false
+    t.text     "handler",                null: false
+    t.text     "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string   "locked_by"
+    t.string   "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
   end
 
   create_table "environments", force: :cascade do |t|

--- a/manifest_delayed_job.yml
+++ b/manifest_delayed_job.yml
@@ -1,0 +1,10 @@
+---
+applications:
+- name: nomis-api-delayed-jobs
+  memory: 256M
+  buildpack: ruby_buildpack
+  command: bundle exec rake jobs:work
+  no-route: true
+  health-check-type: process
+  env:
+    AUTH_ENABLED: false

--- a/script/delayed_job
+++ b/script/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/spec/controllers/admin/environments_controller_spec.rb
+++ b/spec/controllers/admin/environments_controller_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe Admin::EnvironmentsController, type: :controller do
     }
   }
 
+  before(:each) do
+    allow_any_instance_of(Environment).to receive(:update_properties!).and_return(nil)
+  end
+
   context 'when not logged in' do
     let(:session){ empty_session }
 

--- a/spec/factories/access_requests.rb
+++ b/spec/factories/access_requests.rb
@@ -7,11 +7,7 @@ FactoryGirl.define do
     client_pub_key { File.read("#{Rails.root}/spec/fixtures/files/test_client.pub") }
     processed false
     environment do
-      Environment.find_or_create_by!(
-        name: 'dev',
-        provisioning_key: File.read("#{Rails.root}/spec/fixtures/files/test_provisioner.key"),
-        base_url: "https://noms-api.TEST.justice.gov.uk/nomisapi/"
-      )
+      create(:environment)
     end
 
     trait :unprocessed do

--- a/spec/factories/environment.rb
+++ b/spec/factories/environment.rb
@@ -1,9 +1,15 @@
 FactoryGirl.define do
   factory :environment, class: Environment do
-    name 'preprod'
+    name 'dev'
     base_url "https://noms-api.TEST.justice.gov.uk/nomisapi/"
+    
     provisioning_key do
       File.read("#{Rails.root}/spec/fixtures/files/test_provisioner.key")
     end
+
+    health 'DB Up'
+    deployed_version '1.0.0'
+    deployed_version_timestamp Time.now
+    properties_last_checked Time.now
   end
 end

--- a/spec/factories/tokens.rb
+++ b/spec/factories/tokens.rb
@@ -16,11 +16,8 @@ FactoryGirl.define do
     client_pub_key pub.to_pem
     state 'inactive'
     environment do
-      Environment.find_or_create_by!(
-        name: 'preprod',
-        provisioning_key: File.read("#{Rails.root}/spec/fixtures/files/test_provisioner.key"),
-        base_url: "https://noms-api.TEST.justice.gov.uk/nomisapi/"
-      )
+      env = Environment.find_by(name: 'dev')
+      env ? env : create(:environment)
     end
 
     trait :inactive do

--- a/spec/jobs/update_environment_properties_job_spec.rb
+++ b/spec/jobs/update_environment_properties_job_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe UpdateEnvironmentPropertiesJob, type: :job do
+
+  let(:client) do
+    double 'NomisApiClient',
+    get_health: 'updated',
+    get_version: '1.0.1',
+    get_version_timestamp: '2017-09-14 09:56:36'
+  end
+
+  let(:environment) do
+    create(
+      :environment,
+      health: 'stale',
+      deployed_version: '0.0.0',
+      deployed_version_timestamp: Time.now
+    )
+  end
+
+  subject { UpdateEnvironmentPropertiesJob.new(environment) }
+
+  before do
+    Delayed::Worker.delay_jobs = false
+    allow(NomisApiClient).to receive(:new).and_return(client)
+  end
+
+  it 'sets #health' do
+    subject.perform_now
+    expect(environment.health).to eq 'updated'
+  end
+
+  it 'sets #deployed_version' do
+    subject.perform_now
+    expect(environment.deployed_version).to eq '1.0.1'
+  end
+
+  it 'sets #deployed_version_timestamp' do
+    subject.perform_now
+    expect(environment.deployed_version_timestamp.to_s).to eq '2017-09-14 09:56:36 +0100'
+  end
+end

--- a/spec/models/token_spec.rb
+++ b/spec/models/token_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Token, type: :model do
     context 'when environment is present' do
       before { subject.environment = create(:environment) }
       it 'returns the environment name' do
-        expect(subject.environment_name).to eq 'preprod'
+        expect(subject.environment_name).to eq 'dev'
       end
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -79,6 +79,10 @@ RSpec.configure do |config|
       example.run
     end
   end
+
+  config.after(:each) do
+    Delayed::Job.destroy_all
+  end
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/services/retrieve_key_spec.rb
+++ b/spec/services/retrieve_key_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe RetrieveKey do
 
     it 'returns the key content for the given API env' do
       create(:environment)
-      expect( described_class.call('preprod') ).to eq(file_fixture('test_provisioner.key').read)
+      expect( described_class.call('dev') ).to eq(file_fixture('test_provisioner.key').read)
     end
-
   end
 end


### PR DESCRIPTION
- An attempt at this has previously been made https://github.com/ministryofjustice/noms-api-gateway-management/pull/72 and the changes reverted https://github.com/ministryofjustice/noms-api-gateway-management/pull/73

- They were reverted as a quick fix because the jobs were not being preformed, they were just sitting in the queue.
- After reverting the changes, the problem was identified: workers were not being started
- This PR fixes that and adds config to run those jobs on a separate instance from the web-app