### PR TITLE
Fixes bug with revoke notification

### DIFF
--- a/app/controllers/admin/tokens_controller.rb
+++ b/app/controllers/admin/tokens_controller.rb
@@ -50,7 +50,7 @@ class Admin::TokensController < Admin::AdminController
   # PATCH/PUT /tokens/1
   def revoke
     @token.revoke!
-    Notify.revoke_token(@token) if Rails.configuration.notify_enabled 
+    Notify.revoke_token(@token) if Rails.configuration.notify_enabled && @token.contact_email.present?
     redirect_to admin_tokens_url, notice: 'Token was successfully revoked.'
   end
 

--- a/spec/controllers/admin/tokens_controller_spec.rb
+++ b/spec/controllers/admin/tokens_controller_spec.rb
@@ -229,11 +229,25 @@ RSpec.describe Admin::TokensController, type: :controller do
         expect(response).to redirect_to(admin_tokens_url)
       end
 
-      it 'calls Notify.revoke_token' do
-        Rails.configuration.notify_enabled = true
-        expect(Notify).to receive(:revoke_token).with(token)
-        
-        put :revoke, params: {id: token.to_param}, session: session
+      context 'when token has a contact email' do
+        before { Rails.configuration.notify_enabled = true }
+
+        it 'calls Notify.revoke_token' do
+          expect(Notify).to receive(:revoke_token).with(token)
+
+          put :revoke, params: {id: token.to_param}, session: session
+        end
+      end
+
+      context 'when token does not have a contact email' do
+        it 'does not call Notify.revoke_token' do
+          token.update_attribute(:created_from, 'import')
+          token.update_attribute(:contact_email, nil)
+
+          expect(Notify).to_not receive(:revoke_token).with(token.reload)
+
+          put :revoke, params: {id: token.to_param}, session: session
+        end
       end
     end
   end


### PR DESCRIPTION
Where tokens have no contact email, e.g. created from import, does not send revoked notification. This prevents the app from raising an error.