### PR TITLE
add ability to pick common permission patterns from presets

### DIFF
--- a/app/assets/javascripts/admin/tokens.js
+++ b/app/assets/javascripts/admin/tokens.js
@@ -1,7 +1,3 @@
-console.log('here!');
-
-field = null
-dap = null
 
 function strip_excess_whitespace(field) {
   field.val( field.val().trim().replace("\n\n", "\n") );
@@ -11,32 +7,31 @@ function remove_value(field, value) {
   field.val( field.val().replace( value, '' ) );
   strip_excess_whitespace( field )
 }
+
 function add_value(field, value) {
   field.val( field.val() + "\n" + value );
   strip_excess_whitespace( field )
 }
+
 function contains_value(field, value) {
   return field.val().split("\n").includes(value);
 }
+
 function permission_regex(id) {
   key = id.replace('token_permissions_presets-', '');
-  var val = document.all_permissions_flattened[key];
-  return val;
+  return document.all_permissions_flattened[key];
 }
 
 document.all_permissions_flattened = {};
 
 $.getJSON('/admin/tokens/permissions.json', null, function(data) {
   document.all_permissions_flattened = data;
-  dap = data;
 });
 
 $('input[name="token[permissions_presets][]"]').on('change', function() {
   var $txt_area = $('#token_permissions');
   var regex = permission_regex($(this).attr('id'));
   var has_value = contains_value($txt_area, regex );
-
-  console.log( $(this), $txt_area, regex, has_value );
 
   if( $(this)[0].checked ){
     if( !has_value ) {

--- a/app/assets/javascripts/admin/tokens.js
+++ b/app/assets/javascripts/admin/tokens.js
@@ -1,0 +1,48 @@
+console.log('here!');
+
+field = null
+dap = null
+
+function strip_excess_whitespace(field) {
+  field.val( field.val().trim().replace("\n\n", "\n") );
+}
+
+function remove_value(field, value) {
+  field.val( field.val().replace( value, '' ) );
+  strip_excess_whitespace( field )
+}
+function add_value(field, value) {
+  field.val( field.val() + "\n" + value );
+  strip_excess_whitespace( field )
+}
+function contains_value(field, value) {
+  return field.val().split("\n").includes(value);
+}
+function permission_regex(id) {
+  key = id.replace('token_permissions_presets-', '');
+  var val = document.all_permissions_flattened[key];
+  return val;
+}
+
+document.all_permissions_flattened = {};
+
+$.getJSON('/admin/tokens/permissions.json', null, function(data) {
+  document.all_permissions_flattened = data;
+  dap = data;
+});
+
+$('input[name="token[permissions_presets][]"]').on('change', function() {
+  var $txt_area = $('#token_permissions');
+  var regex = permission_regex($(this).attr('id'));
+  var has_value = contains_value($txt_area, regex );
+
+  console.log( $(this), $txt_area, regex, has_value );
+
+  if( $(this)[0].checked ){
+    if( !has_value ) {
+      add_value( $txt_area, regex );
+    }
+  } else if( has_value ) {
+    remove_value( $txt_area, regex );
+  }
+} );

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  before_action :setup_required_vars
 
   def current_user
     # TODO: in a real application lookup User record from session['sso_id']
@@ -15,5 +16,9 @@ class ApplicationController < ActionController::Base
         session[:redirect_path] = request.original_fullpath
         redirect_to '/auth/mojsso'
       end
+    end
+
+    def setup_required_vars
+      @scripts = []
     end
 end

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -1,0 +1,31 @@
+class Permission
+  def self.all
+    {
+      all: {
+        all:    '.*'
+      },
+      elite2_api: {
+        all:    '^\/elite2api\/.*$',
+        health: '^\/elite2api\/info\/health.*$'
+      },
+      nomis_api: {
+        health: '^\/nomisapi\/health$',
+        all: '^\/nomisapi\/.*$'
+      }   
+    }
+  end
+
+  def self.flattened
+    flattened_perms={}
+    all.each do |scope,keys|
+      keys.each do |key,val|
+        flattened_perms[compound_key(scope, key)]=val
+      end
+    end
+    flattened_perms
+  end
+
+  def self.compound_key( scope, key )
+    [scope, key].map(&:to_s).join('-')
+  end
+end

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -1,6 +1,5 @@
 class Permission
-  def self.all
-    {
+  PERMISSIONS = {
       all: {
         all:    '.*'
       },
@@ -12,7 +11,10 @@ class Permission
         health: '^\/nomisapi\/health$',
         all: '^\/nomisapi\/.*$'
       }   
-    }
+    }.freeze
+    
+  def self.all
+    PERMISSIONS
   end
 
   def self.flattened

--- a/app/views/admin/tokens/_form.html.haml
+++ b/app/views/admin/tokens/_form.html.haml
@@ -5,44 +5,62 @@
   - if @access_request.present?
     = hidden_field_tag :access_request_id, @access_request.id
 
-  .field
-    = f.text_field :requested_by
-  .field
-    = f.text_field :service_name
-  .field
-    = f.text_field :contact_email
-  .field
-    = f.collection_select :environment_id, Environment.all, :id, :name, prompt: true
-  .field
-    .form-group
-      = f.label :expires, class: 'form-label' do
-        Expires
-        %span.form-hint
-          %p
-            When this token will expire. Default is 1 year from issue.
-        = f.date_field :expires, value: 1.year.from_now.to_date
 
-  .field
-    = f.text_area :permissions
+  = f.text_field :requested_by
+
+  = f.text_field :service_name
+
+  = f.text_field :contact_email
+
+  = f.collection_select :environment_id, Environment.all, :id, :name, prompt: true
+
+  .form-group
+    = f.label :expires, class: 'form-label' do
+      Expires
+      %span.form-hint
+        %p
+          When this token will expire. Default is 1 year from issue.
+      = f.date_field :expires, value: 1.year.from_now.to_date
+
+
+          
+
+  .form-group
+    = f.text_area :permissions, hint_text: 'blah', rows: 6, cols: 40
+
+    %details
+      %summary
+        %span.summary
+          Common permissions presets
+      .panel.panel-border-narrow.multiple-choice
+        - @permissions.each do |scope, permissions|
+          - permissions.each do |label, regex|
+            - scoped_label =  [scope, label].map(&:to_s).join('-')
+            - check_box_id = "permissions_presets-#{scope}-#{label}"
+            = f.label check_box_id, class: 'form-label' do
+              = check_box_tag "token[permissions_presets][]",
+                                scoped_label,
+                                params[:token].try(:[], :permissions_presets).to_a.include?(scoped_label.to_s),
+                                id: "token_#{check_box_id}",
+                                class: 'check-box'
+              = I18n.t(label, scope: [:permissions, scope])
 
   - if @token.client_pub_key.present? && @token.errors[:client_pub_key].blank?
-    %p
-    .field
-      = f.text_area :client_pub_key, readonly: true, rows: 6
+    
+    = f.text_area :client_pub_key, readonly: true, rows: 6
 
   - else
-    .field
-      .form-group{ class: ('form-group-error' if @token.errors[:client_pub_key]).present? }
-        = f.label :client_pub_key_file, class: 'form-label' do
-          Client public key
-          %span.form-hint
-            %p
-              Supplied by requester.
-        - if @token.errors[:client_pub_key].present?
-          .error-message
-            = "Client pub key " + @token.errors[:client_pub_key].first
-        = f.file_field :client_pub_key_file
-        = f.hidden_field :client_pub_key, value: @token.client_pub_key
+    .form-group{ class: ('form-group-error' if @token.errors[:client_pub_key]).present? }
+      = f.label :client_pub_key_file, class: 'form-label' do
+        Client public key
+        %span.form-hint
+          %p
+            Supplied by requester.
+      - if @token.errors[:client_pub_key].present?
+        .error-message
+          = "Client pub key " + @token.errors[:client_pub_key].first
+      = f.file_field :client_pub_key_file
+      = f.hidden_field :client_pub_key, value: @token.client_pub_key
 
   .actions
     = f.submit @token.new_record? ? 'Create' : 'Save', class: 'button'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,6 +62,18 @@ en:
           - If you need to use more than one regex, put each one on a separate line.<br>
           - Using `.*` will grant access to all endpoints.<br>
           - Using `^\/nomisapi\/health$` will grant access to the health endpoint only.
+  permissions:
+    all:
+      all: All endpoints on all APIs
+      title: All
+    elite2_api:
+      all: All ELITE2 endpoints
+      health: The ELITE2 healthcheck
+      title: ELITE2 API
+    nomis_api:
+      all: All NOMIS API endpoints
+      health: The NOMIS API healthcheck
+      title: NOMIS API
   time:
     formats:
       default: "%Y-%m-%d"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
     resources :tokens, except: [:edit, :update, :destroy] do
       put :revoke, on: :member
       patch :revoke, on: :member
+      get :permissions, on: :collection
     end
     resources :access_requests, except: [:new, :create, :edit, :update]
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -59,6 +59,13 @@ ActiveRecord::Schema.define(version: 20171031144858) do
     t.integer  "interval",                   default: 10
   end
 
+  create_table "provisioning_keys", force: :cascade do |t|
+    t.string   "api_env"
+    t.text     "content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "tokens", force: :cascade do |t|
     t.datetime "issued_at"
     t.string   "requested_by"

--- a/spec/models/permission_spec.rb
+++ b/spec/models/permission_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Permission, type: :model do
+
+  describe '.flattened' do
+    it 'returns a hash' do
+      expect( Permission.flattened ).to be_a(Hash)
+    end
+
+    describe 'returned Hash' do
+      describe 'each key' do
+        Permission.flattened.each do |key, val|
+          it 'has a string value' do
+            expect( val ).to be_a(String)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This reworks the previous PR #75 as follows:

- provide a set of checkboxes that populate the permissions with common regexes, via JS alone
- remove the TokenPermission model + migrations

<img width="684" alt="screen shot 2018-01-03 at 12 10 15" src="https://user-images.githubusercontent.com/134501/34520084-1cfdbc84-f07f-11e7-97c6-8956c66e3018.png">
