### PR TITLE
Travis: use latest version of ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.3.0
+  - 2.3
 cache: bundler
 addons:
   postgresql: '9.3'


### PR DESCRIPTION
Removes a warning that 2.3.0 is outdated

<img width="790" alt="screen shot 2018-04-04 at 12 02 58" src="https://user-images.githubusercontent.com/8659/38304117-2eff5d2a-3800-11e8-8798-6fe14740c9cf.png">
