### PR TITLE
Run docker build on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,6 @@ before_script:
 script:
   - bundle exec rake db:migrate
   - bundle exec rspec
+  - docker build .
+services:
+  - docker


### PR DESCRIPTION
Upsides:

* hit issues building the docker image before they get merged

Downsides:

* makes the travis build ~25 seconds slower